### PR TITLE
[Python] Toggle multilines for argument and paramter list.

### DIFF
--- a/lua/ts-node-action/filetypes/python.lua
+++ b/lua/ts-node-action/filetypes/python.lua
@@ -13,8 +13,9 @@ local function toggle_boolean(node)
 end
 
 return {
-  ["dictionary"] = toggle_multiline,
-  ["list"]       = toggle_multiline,
-  ["true"]       = toggle_boolean,
-  ["false"]      = toggle_boolean,
+  ["dictionary"]    = toggle_multiline,
+  ["list"]          = toggle_multiline,
+  ["argument_list"] = toggle_multiline,
+  ["true"]          = toggle_boolean,
+  ["false"]         = toggle_boolean,
 }

--- a/lua/ts-node-action/filetypes/python.lua
+++ b/lua/ts-node-action/filetypes/python.lua
@@ -16,6 +16,7 @@ return {
   ["dictionary"]    = toggle_multiline,
   ["list"]          = toggle_multiline,
   ["argument_list"] = toggle_multiline,
+  ["parameters"]    = toggle_multiline,
   ["true"]          = toggle_boolean,
   ["false"]         = toggle_boolean,
 }


### PR DESCRIPTION
Toggle multi-line for argument and parameter list, i.e function call and function definition.