### PR TITLE
Add dot-repeat support

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,6 +50,8 @@ For example, this would bind the function to `K`:
 vim.keymap.set({ "n" }, "K", require("ts-node-action").node_action, { desc = "Trigger Node Action" })
 ```
 
+If `tpope/vim-repeat` is installed, calling `node_action()` is dot-repeatable.
+
 ## Configuration
 
 The `setup()` function accepts a table that conforms to the following schema:
@@ -102,10 +104,10 @@ This function can return one or two values:
 Here's how that can look.
 
 ```lua
-{ 
-  cursor   = { row = 0, col = 0 }, 
-  callback = function() ... end, 
-  format   = true 
+{
+  cursor   = { row = 0, col = 0 },
+  callback = function() ... end,
+  format   = true
 }
 ```
 

--- a/doc/ts-node-action.txt
+++ b/doc/ts-node-action.txt
@@ -1,4 +1,4 @@
-*ts-node-action.txt*        For NVIM v0.8.0       Last change: 2023 January 12
+*ts-node-action.txt*        For NVIM v0.8.0       Last change: 2023 January 13
 
 ==============================================================================
 Table of Contents                           *ts-node-action-table-of-contents*
@@ -93,6 +93,8 @@ For example, this would bind the function to `K`:
 <
 
 
+If `tpope/vim-repeat` is installed, calling `node_action()` is dot-repeatable.
+
 CONFIGURATION                                   *ts-node-action-configuration*
 
 The `setup()` function accepts a table that conforms to the following schema:
@@ -156,10 +158,10 @@ This function can return one or two values:
 Here’s how that can look.
 
 >
-    { 
-      cursor   = { row = 0, col = 0 }, 
-      callback = function() ... end, 
-      format   = true 
+    {
+      cursor   = { row = 0, col = 0 },
+      callback = function() ... end,
+      format   = true
     }
 <
 

--- a/lua/ts-node-action/init.lua
+++ b/lua/ts-node-action/init.lua
@@ -64,7 +64,7 @@ function M.setup(opts)
   M.node_actions = vim.tbl_deep_extend("force", M.node_actions, opts or {})
 end
 
-function M.node_action()
+M.node_action = require("ts-node-action.repeat").set(function()
   local node = require("nvim-treesitter.ts_utils").get_node_at_cursor()
   if not node then
     info("No node found at cursor")
@@ -94,7 +94,7 @@ function M.node_action()
   else
     info("No action defined for '" .. vim.o.filetype .. "' node type: '" .. node:type() .. "'")
   end
-end
+end)
 
 function M.debug()
   local node = require("nvim-treesitter.ts_utils").get_node_at_cursor()

--- a/lua/ts-node-action/repeat.lua
+++ b/lua/ts-node-action/repeat.lua
@@ -1,0 +1,24 @@
+-- https://github.com/lewis6991/gitsigns.nvim/blob/main/lua/gitsigns/repeat.lua
+local M = {}
+
+function M.set(fn)
+  return function(...)
+    local args          = { ... }
+    local nargs         = select('#', ...)
+    vim.go.operatorfunc = "v:lua.require'ts-node-action.repeat'.repeat_action"
+
+    M.repeat_action = function()
+      fn(unpack(args, 1, nargs))
+
+      local action = vim.api.nvim_replace_termcodes(
+        string.format('<cmd>call %s()<cr>', vim.go.operatorfunc), true, true, true
+      )
+
+      pcall(vim.fn["repeat#set"], action, -1)
+    end
+
+    vim.cmd('normal! g@l')
+  end
+end
+
+return M


### PR DESCRIPTION
If you have `tpope/vim-repeat` installed, calling `node_action()` will be repeated. Runs the correct function for whatever node is under cursor.

Closes #11 