### PR TITLE
Reimplement cycle_case to allow user specified formats/ordering

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,9 +21,7 @@ A framework for running functions on Tree-sitter nodes, and updating the buffer 
 {
     'ckolkey/ts-node-action',
      dependencies = { 'nvim-treesitter' },
-     config = function() -- Optional
-         require("ts-node-action").setup({})
-     end
+     opts = {},
 },
 ```
 
@@ -32,14 +30,17 @@ A framework for running functions on Tree-sitter nodes, and updating the buffer 
 use({
     'ckolkey/ts-node-action',
      requires = { 'nvim-treesitter' },
-     config = function() -- Optional
+     config = function()
          require("ts-node-action").setup({})
      end
 })
 ```
 
-**Note**: It's not required to call `require("ts-node-action").setup()` to initialize the plugin, but a table can be
-passed into the setup function to specify new actions for nodes or additional filetypes.
+**Note**: It's not required to call `require("ts-node-action").setup()` to initialize the plugin,
+but a table can be passed into the setup function to specify new actions for nodes or additional filetypes.
+
+Additionally, `:NodeAction` and `:NodeActionDebug` user commands are defined in the `setup()` function,
+so you'll need to call it if you want to use those.
 
 ## Usage
 

--- a/README.md
+++ b/README.md
@@ -172,6 +172,41 @@ Nodes not specified in table are returned unchanged.
 
 ## Builtin Actions
 
+<details>
+<summary>Cycle Case</summary>
+
+`require("ts-node-action.actions").cycle_case(formats)`
+
+```
+@param formats table|nil
+```
+
+`formats` param can be a table of strings specifying the different formats to cycle through. By default it's `{
+  "snake_case", "pascal_case", "screaming_snake_case", "camel_case" }`.
+
+A table can also be used in place of a string to implement a custom formatter. Every format is a table that implements the following interface:
+- pattern (string)
+- apply (function)
+- standardize (function)
+
+# Pattern
+A Lua pattern (string) that matches the format
+
+# Apply
+A function that takes a _table_ of standardized strings as it's argument, and returns a _string_ in the format
+
+# Standardize
+A function that takes a _string_ in this format, and returns a table of strings, all lower case, no special chars.
+ie: standardize("ts_node_action") -> { "ts", "node", "action" }
+    standardize("tsNodeAction")   -> { "ts", "node", "action" }
+    standardize("TsNodeAction")   -> { "ts", "node", "action" }
+    standardize("TS_NODE_ACTION") -> { "ts", "node", "action" }
+
+NOTE: The order of formats can be important, as some identifiers are the same for multiple formats.
+  Take the string 'action' for example. This is a match for both snake_case _and_ camel_case. It's
+  therefore important to place a format between those two so we can correcly change the string.
+</details>
+
 Builtin actions are all higher-order functions so they can easily have options overridden on a per-filetype basis. Check out the implementations under `lua/filetypes/` to see how!
 
 ```lua

--- a/lua/ts-node-action/actions/cycle_case.lua
+++ b/lua/ts-node-action/actions/cycle_case.lua
@@ -1,97 +1,117 @@
 local helpers = require("ts-node-action.helpers")
 
-local snake_case = {
-  check = function(text)
-    return (string.find(text, "_")
-        and string.sub(text, 1, 1) == string.sub(text, 1, 1):lower())
-        or text:lower() == text
-  end,
+-- API Notes:
+-- Every format is a table that implements the following three keys:
+-- - pattern
+-- - apply
+-- - standardize
+--
+-- # Pattern
+-- A Lua pattern (string) that matches the format
+--
+-- # Apply
+-- A function that takes a _table_ of standardized strings as it's argument, and returns a _string_ in the format
+--
+-- # Standardize
+-- A function that takes a _string_ in this format, and returns a table of strings, all lower case, no special chars.
+-- ie: standardize("ts_node_action") -> { "ts", "node", "action" }
+--     standardize("tsNodeAction")   -> { "ts", "node", "action" }
+--     standardize("TsNodeAction")   -> { "ts", "node", "action" }
+--     standardize("TS_NODE_ACTION") -> { "ts", "node", "action" }
+--
+-- NOTE: The order of formats can be important, as some identifiers are the same for multiple formats.
+--   Take the string 'action' for example. This is a match for both snake_case _and_ camel_case. It's
+--   therefore important to place a format between those two so we can correcly change the string.
 
-  transform = function(tbl)
-    return string.lower(table.concat(tbl, "_"))
-  end,
+local format_table = {
+  snake_case = {
+    pattern = "^%l+[%l_]*$",
+    apply = function(tbl)
+      return string.lower(table.concat(tbl, "_"))
+    end,
+    standardize = function(text)
+      return vim.split(string.lower(text), "_", { trimempty = true })
+    end
+  },
+  camel_case = {
+    pattern = "^%l+[%u%l]*$",
+    apply = function(tbl)
+      local tmp = vim.tbl_map(function(word)
+        return word:gsub("^.", string.upper)
+      end, tbl)
+      local value, _ = table.concat(tmp, ""):gsub("^.", string.lower)
+      return value
+    end,
+    standardize = function(text)
+      return vim.split(
+        text:gsub(".%f[%l]", " %1"):gsub("%l%f[%u]", "%1 "):gsub("^.", string.upper), " ",
+        { trimempty = true }
+      )
+    end
+  },
+  pascal_case = {
+    pattern = "^%u%l+[%u%l]*$",
+    apply = function(tbl)
+      local value, _ = table.concat(
+        vim.tbl_map(function(word) return word:gsub("^.", string.upper) end, tbl), ""
+      )
+      return value
+    end,
+    standardize = function(text)
+      return vim.split(
+        text:gsub(".%f[%l]", " %1"):gsub("%l%f[%u]", "%1 "):gsub("^.", string.upper), " ",
+        { trimempty = true }
+      )
+    end
+  },
+  screaming_snake_case = {
+    pattern = "^%u+[%u_]*$",
+    apply = function(tbl)
+      local value, _ = table.concat(
+        vim.tbl_map(function(word) return word:upper() end, tbl), "_"
+      )
 
-  standardize = function(text)
-    return vim.split(string.lower(text), "_", { trimempty = true })
-  end
+      return value
+    end,
+    standardize = function(text)
+      return vim.split(string.lower(text), "_", { trimempty = true })
+    end
+  }
 }
 
-local camel_case = {
-  transform = function(tbl)
-    local tmp = vim.tbl_map(function(word)
-      return word:gsub("^.", string.upper)
-    end, tbl)
-    local value, _ = table.concat(tmp, ""):gsub("^.", string.lower)
-    return value
-  end,
+local function check_pattern(text, pattern)
+  return not not string.find(text, pattern)
+end
 
-  standardize = function(text)
-    local tmp = text:gsub(".%f[%l]", " %1"):gsub("%l%f[%u]", "%1 "):gsub("^.", string.upper)
-    return vim.split(tmp, " ", { trimempty = true })
-  end
-}
+local default_formats = { "snake_case", "pascal_case", "screaming_snake_case", "camel_case" }
 
-local pascal_case = {
-  check = function(text)
-    return string.sub(text, 1, 1) == string.sub(text, 1, 1):upper()
-  end,
+return function(user_formats)
+  user_formats = user_formats or default_formats
 
-  transform = function(tbl)
-    local tmp = vim.tbl_map(function(word)
-      return word:gsub("^.", string.upper)
-    end, tbl)
-
-    local value, _ = table.concat(tmp, "")
-
-    return value
-  end,
-
-  standardize = function(text)
-    local tmp = text:gsub(".%f[%l]", " %1"):gsub("%l%f[%u]", "%1 "):gsub("^.", string.upper)
-    return vim.split(tmp, " ", { trimempty = true })
-  end
-}
-
-local screaming_snake_case = {
-  check = function(text)
-    return string.sub(text, 1, 2) == string.sub(text, 1, 2):upper()
-  end,
-
-  transform = function(tbl)
-    local tmp = vim.tbl_map(function(word)
-      return word:upper()
-    end, tbl)
-
-    local value, _ = table.concat(tmp, "_")
-
-    return value
-  end,
-
-  standardize = function(text)
-    return vim.split(string.lower(text), "_", { trimempty = true })
-  end
-}
-
-return function()
-  return function(node)
-    local text = helpers.node_text(node)
-    local standardize
-    local transform
-
-    if snake_case.check(text) then
-      standardize = snake_case.standardize
-      transform   = pascal_case.transform
-    elseif screaming_snake_case.check(text) then
-      standardize = screaming_snake_case.standardize
-      transform   = camel_case.transform
-    elseif pascal_case.check(text) then
-      standardize = pascal_case.standardize
-      transform   = screaming_snake_case.transform
-    else
-      standardize = camel_case.standardize
-      transform   = snake_case.transform
+  local formats = {}
+  for _, format in ipairs(user_formats) do
+    if type(format) == "string" then
+      format = format_table[format]
     end
 
-    return transform(standardize(text))
+    if format then
+      table.insert(formats, format)
+    else
+      print("TS:NodeAction:CycleCase - Format '" .. format .. "' is invalid")
+    end
+  end
+
+  return function(node)
+    local text = helpers.node_text(node)
+
+    for i, format in ipairs(formats) do
+      if check_pattern(text, format.pattern) then
+        local next_i      = i + 1 > #formats and 1 or i + 1
+        local apply       = formats[next_i].apply
+        local standardize = format.standardize
+
+        return apply(standardize(text))
+      end
+    end
   end
 end

--- a/lua/ts-node-action/filetypes/ruby.lua
+++ b/lua/ts-node-action/filetypes/ruby.lua
@@ -14,6 +14,8 @@ local padding = {
   ["/"]  = " %s ",
 }
 
+local identifier_formats = { "snake_case", "pascal_case", "screaming_snake_case" }
+
 local function toggle_block(node)
   local block_params
   local block_body = ""
@@ -159,8 +161,8 @@ local function toggle_hash_style(node)
 end
 
 return {
-  ["identifier"]        = actions.cycle_case({ "snake_case", "pascal_case", "screaming_snake_case" }),
-  ["constant"]          = actions.cycle_case({ "snake_case", "pascal_case", "screaming_snake_case" }),
+  ["identifier"]        = actions.cycle_case(identifier_formats),
+  ["constant"]          = actions.cycle_case(identifier_formats),
   ["binary"]            = actions.toggle_operator(),
   ["array"]             = actions.toggle_multiline(padding),
   ["hash"]              = actions.toggle_multiline(padding),

--- a/lua/ts-node-action/filetypes/ruby.lua
+++ b/lua/ts-node-action/filetypes/ruby.lua
@@ -159,7 +159,8 @@ local function toggle_hash_style(node)
 end
 
 return {
-  ["constant"]          = actions.cycle_case(),
+  ["identifier"]        = actions.cycle_case({ "snake_case", "pascal_case", "screaming_snake_case" }),
+  ["constant"]          = actions.cycle_case({ "snake_case", "pascal_case", "screaming_snake_case" }),
   ["binary"]            = actions.toggle_operator(),
   ["array"]             = actions.toggle_multiline(padding),
   ["hash"]              = actions.toggle_multiline(padding),

--- a/lua/ts-node-action/init.lua
+++ b/lua/ts-node-action/init.lua
@@ -76,6 +76,18 @@ M.node_actions = require("ts-node-action.filetypes")
 -- @return nil
 function M.setup(opts)
   M.node_actions = vim.tbl_deep_extend("force", M.node_actions, opts or {})
+
+  vim.api.nvim_create_user_command(
+    "NodeAction",
+    M.node_action,
+    { desc = "Performs action on the node under the cursor." }
+  )
+
+  vim.api.nvim_create_user_command(
+    "NodeActionDebug",
+    M.debug,
+    { desc = "Prints debug information for Ts-Node-Action Plugin" }
+  )
 end
 
 function M.node_action()


### PR DESCRIPTION
This doesn't change the default behaviour of `cycle_case`, but allows a user to specify a new order for case-cycling, or new formats entirely. To use a built-in order, simply pass the string value for that format (one of `{ "snake_case", "pascal_case", "screaming_snake_case", "camel_case" }`).

To provide a custom value, instead of passing a string, pass a table that conforms to:
`{
  pattern = string,
  apply = function,
  standardize = function
}`

Closes #15 