### PR TITLE
[Python] toggle_multiline comprehensions and "if/else <-> ternary"

### DIFF
--- a/README.md
+++ b/README.md
@@ -257,7 +257,7 @@ Builtin actions are all higher-order functions so they can easily have options o
 | `toggle_multiline()` |  | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ |  |
 | `toggle_operator()` |  | ✅ | ✅ | ✅ | ✅ | ✅ |  |  |  |
 | `toggle_block()` |  | ✅ |  |  |  |  |  |  |  |
-| if/else <-> ternery |  | ✅ |  |  |  |  |  |  |  |
+| if/else <-> ternery |  | ✅ |  |  | ✅ |  |  |  |  |
 | if block/postfix |  | ✅ |  |  |  |  |  |  |  |
 | `toggle_hash_style()` |  | ✅ |  |  |  |  |  |  |  |
 | `conceal_string()` |  |  | ✅ |  |  |  |  |  | ✅ |

--- a/lua/ts-node-action/actions/toggle_multiline.lua
+++ b/lua/ts-node-action/actions/toggle_multiline.lua
@@ -11,7 +11,7 @@ local function collapse_child_nodes(padding)
       if child:named_child_count() > 0 then
         prev_text = nil
         table.insert(replacement, collapse(child))
-      else
+      elseif child:type() ~= "comment" then
         prev_text = helpers.padded_node_text(child, padding, prev_text)
         table.insert(replacement, prev_text)
       end

--- a/lua/ts-node-action/actions/toggle_multiline.lua
+++ b/lua/ts-node-action/actions/toggle_multiline.lua
@@ -5,22 +5,22 @@ local function collapse_child_nodes(padding)
 
   local function collapse(node)
     local replacement = {}
-    local text
-    local prev_text
+    local child_text
+    local context
 
     for child, _ in node:iter_children() do
       if child:named_child_count() > 0 then
-        text = collapse(child)
-        if text == nil then
+        child_text = collapse(child)
+        if child_text == nil then
           return
         end
-        table.insert(replacement, text)
-        prev_text = nil
+        table.insert(replacement, child_text)
+        context = nil
       elseif child:type() == "comment" then
         return
       else
-        prev_text = helpers.padded_node_text(child, padding, prev_text)
-        table.insert(replacement, prev_text)
+        context = helpers.padded_node_text(child, padding, context)
+        table.insert(replacement, context)
       end
     end
 

--- a/lua/ts-node-action/actions/toggle_multiline.lua
+++ b/lua/ts-node-action/actions/toggle_multiline.lua
@@ -3,12 +3,15 @@ local helpers = require("ts-node-action.helpers")
 local function collapse_child_nodes(padding)
   return function(node)
     local replacement = {}
+    local prev_text
 
     for child, _ in node:iter_children() do
       if child:named_child_count() > 0 then
+        prev_text = nil
         table.insert(replacement, collapse_child_nodes(padding)(child))
       else
-        table.insert(replacement, helpers.padded_node_text(child, padding))
+        prev_text = helpers.padded_node_text(child, padding, prev_text)
+        table.insert(replacement, prev_text)
       end
     end
 

--- a/lua/ts-node-action/actions/toggle_multiline.lua
+++ b/lua/ts-node-action/actions/toggle_multiline.lua
@@ -5,13 +5,20 @@ local function collapse_child_nodes(padding)
 
   local function collapse(node)
     local replacement = {}
+    local text
     local prev_text
 
     for child, _ in node:iter_children() do
       if child:named_child_count() > 0 then
+        text = collapse(child)
+        if text == nil then
+          return
+        end
+        table.insert(replacement, text)
         prev_text = nil
-        table.insert(replacement, collapse(child))
-      elseif child:type() ~= "comment" then
+      elseif child:type() == "comment" then
+        return
+      else
         prev_text = helpers.padded_node_text(child, padding, prev_text)
         table.insert(replacement, prev_text)
       end

--- a/lua/ts-node-action/actions/toggle_multiline.lua
+++ b/lua/ts-node-action/actions/toggle_multiline.lua
@@ -1,14 +1,16 @@
 local helpers = require("ts-node-action.helpers")
 
 local function collapse_child_nodes(padding)
-  return function(node)
+  padding = padding or {}
+
+  local function collapse(node)
     local replacement = {}
     local prev_text
 
     for child, _ in node:iter_children() do
       if child:named_child_count() > 0 then
         prev_text = nil
-        table.insert(replacement, collapse_child_nodes(padding)(child))
+        table.insert(replacement, collapse(child))
       else
         prev_text = helpers.padded_node_text(child, padding, prev_text)
         table.insert(replacement, prev_text)
@@ -17,6 +19,8 @@ local function collapse_child_nodes(padding)
 
     return table.concat(vim.tbl_flatten(replacement))
   end
+
+  return collapse
 end
 
 local function expand_child_nodes(node)

--- a/lua/ts-node-action/filetypes/python.lua
+++ b/lua/ts-node-action/filetypes/python.lua
@@ -1,23 +1,153 @@
+local helpers = require("ts-node-action.helpers")
 local actions = require("ts-node-action.actions")
+local txt     = function(val) return helpers.node_text(val) end
 
+-- private
+-- @param block tsnode
+-- @return string, string|nil
+local function block_text_lhs_rhs(block)
+  local lhs
+  local rhs
+  if block:type() == "return_statement" then
+    lhs = "return "
+    rhs = txt(block:named_child(0))
+  elseif block:type() == "expression_statement" and
+         block:named_child(0):type() == "assignment" then
+    local assignment = block:named_child(0)
+    local identifier = assignment:named_child(0)
+    lhs = txt(identifier) .. " = "
+    rhs = txt(assignment:named_child(1))
+  else
+    return nil
+  end
+  return lhs, rhs
+end
+
+local function inline_if(if_statement)
+  local condition   = if_statement:named_child(0)
+  local consequence = if_statement:named_child(1):named_child(0)
+  local replacement = {}
+  local lhs, rhs = block_text_lhs_rhs(consequence)
+  if lhs == nil then
+    return
+  end
+  table.insert(
+    replacement,
+    lhs .. rhs .. " if " .. txt(condition) .. " else None"
+  )
+  local cursor_col = string.len(lhs .. rhs) + 1
+  return replacement, { cursor = { col = cursor_col }, format = true }
+end
+
+local function inline_ifelse(if_statement)
+  local condition   = if_statement:named_child(0)
+  local consequence = if_statement:named_child(1):named_child(0)
+  local alternative = if_statement:named_child(2):named_child(0):named_child(0)
+  local replacement = {}
+  local lhs, conseq_text = block_text_lhs_rhs(consequence)
+  if lhs == nil then
+    return
+  end
+  local lhs2, alter_text = block_text_lhs_rhs(alternative)
+  if lhs ~= lhs2 or alter_text == nil then
+    return
+  end
+  table.insert(
+    replacement,
+    lhs .. conseq_text .. " if " .. txt(condition) .. " else " .. alter_text
+  )
+  local cursor_col = string.len(lhs .. conseq_text) + 1
+  return replacement, { cursor = { col = cursor_col }, format = true }
+end
+
+local function inline_if_stmt(if_statement)
+  if if_statement:named_child_count() == 3 then
+    return inline_ifelse(if_statement)
+  elseif if_statement:named_child_count() == 2 then
+    return inline_if(if_statement)
+  end
+end
+
+local function expand_if(conditional_expression)
+  local assignment  = conditional_expression:parent()
+  local identifier  = assignment:named_child(0)
+  local condition   = conditional_expression:named_child(1)
+  local consequence = conditional_expression:named_child(0)
+  local alternative = conditional_expression:named_child(2)
+  local replacement = {}
+  table.insert(replacement, "if " .. txt(condition) .. ":")
+  table.insert(replacement, " " .. txt(identifier) .. " = " .. txt(consequence))
+  table.insert(replacement, "else:")
+  table.insert(replacement, " " .. txt(identifier) .. " = " .. txt(alternative))
+  return replacement, { cursor = {}, format = true }, assignment
+end
+
+-- Special cases:
+-- Because "is" and "not" are valid by themselves, they are seen as separate
+-- unnamed nodes by TS.  This means that without special handling, a config of:
+-- {
+--   ["is"]  = " %s ",
+--   ["not"] = " %s "
+-- }
+-- would be padded as ` is  not `.  To avoid this, we can make them smarter by
+-- defining a padding rule for the case of when "not" is seen after "is".
+--
+-- There is also the identical case of "not in". However, "-" is both a
+-- unary and binary operator.  When it is used as a binary operator, it is
+-- a normal case.  For unary, we don't want any padding, and generally (always?)
+-- it is preceded by a named node.  When padding, we see these as
+-- prev_text=nil, so we can use that to detect the unary case with a special
+-- key "nil", to represent it.
 local padding = {
-  [","] = "%s ",
-  [":"] = "%s ",
-  ["{"] = "%s ",
-  ["}"] = " %s",
+  [","]      = "%s ",
+  [":"]      = "%s ",
+  ["{"]      = "%s",
+  ["}"]      = "%s",
+  ["for"]    = " %s ",
+  ["if"]     = " %s ",
+  ["else"]   = " %s ",
+  ["and"]    = " %s ",
+  ["or"]     = " %s ",
+  ["is"]     = " %s ",
+  ["not"]    = { [""] = " %s ", ["is"]  = "%s " },
+  ["in"]     = { [""] = " %s ", ["not"] = "%s " },
+  ["=="]     = " %s ",
+  ["!="]     = " %s ",
+  [">="]     = " %s ",
+  ["<="]     = " %s ",
+  [">"]      = " %s ",
+  ["<"]      = " %s ",
+  ["+"]      = " %s ",
+  ["-"]      = { [""] = " %s ", ["nil"] = "%s", },
+  ["*"]      = " %s ",
+  ["/"]      = " %s ",
+  ["//"]     = " %s ",
+  ["%"]      = " %s ",
+  ["**"]     = " %s ",
+  ["lambda"] = " %s ",
+  ["with"]   = " %s ",
+  ["as"]     = " %s ",
 }
 
 local boolean_override = {
-  ["True"]  = "False",
+  ["True"] = "False",
   ["False"] = "True",
 }
 
 return {
-  ["dictionary"]          = actions.toggle_multiline(padding),
-  ["list"]                = actions.toggle_multiline(padding),
-  ["argument_list"]       = actions.toggle_multiline(padding),
-  ["parameters"]          = actions.toggle_multiline(padding),
-  ["true"]                = actions.toggle_boolean(boolean_override),
-  ["false"]               = actions.toggle_boolean(boolean_override),
-  ["comparison_operator"] = actions.toggle_operator(),
+  ["dictionary"]               = actions.toggle_multiline(padding),
+  ["set"]                      = actions.toggle_multiline(padding),
+  ["list"]                     = actions.toggle_multiline(padding),
+  ["tuple"]                    = actions.toggle_multiline(padding),
+  ["argument_list"]            = actions.toggle_multiline(padding),
+  ["parameters"]               = actions.toggle_multiline(padding),
+  ["list_comprehension"]       = actions.toggle_multiline(padding),
+  ["set_comprehension"]        = actions.toggle_multiline(padding),
+  ["dictionary_comprehension"] = actions.toggle_multiline(padding),
+  ["generator_expression"]     = actions.toggle_multiline(padding),
+  ["true"]                     = actions.toggle_boolean(boolean_override),
+  ["false"]                    = actions.toggle_boolean(boolean_override),
+  ["comparison_operator"]      = actions.toggle_operator(),
+  ["conditional_expression"]   = { { expand_if, name = "Expand If Stmt" } },
+  ["if_statement"]             = { { inline_if_stmt, name = "Inline If Stmt" } },
 }

--- a/lua/ts-node-action/filetypes/python.lua
+++ b/lua/ts-node-action/filetypes/python.lua
@@ -1,324 +1,6 @@
 local helpers = require("ts-node-action.helpers")
 local actions = require("ts-node-action.actions")
 
-
--- When inlined, these nodes must be parenthesized to avoid changing the
--- meaning of the code and to avoid syntax errors.
--- eg: x = lambda y: y + 1 if y else 0
---     x = (lambda y: y + 1) if y else 0
--- Both are valid, but the first is not equivalent to the second.
--- Unlike the second, the first can not be expanded to:
---    if y:
---        x = lambda y: y + 1
---    else:
---        x = 0
--- because the if/else is part of the lambda expression.
--- private
-local node_types_to_parenthesize = {
-  ["conditional_expression"] = true,
-  ["lambda"] = true,
-}
-
--- Helper that returns the text of the left and right hand sides of a
--- statement. For example, the left hand side of:
---
---  - `return 1` is `return` and the right hand side is `1`.
---  - `x = 1` is `x = ` and the right hand side is `1`.
---  - `x = y = z = 1` is `x = y = z = ` and the right hand side is `1`.
---  - `print(3)` is `print` and the right hand side is `(3)`.
---
--- private
--- @param node tsnode
--- @return string|nil, string|nil, string
-local function node_text_lhs_rhs(node)
-  local lhs  = nil
-  local rhs  = nil
-  local type = node:type()
-
-  if type == "return_statement" then
-    lhs = "return "
-    rhs = helpers.node_text(node:named_child(0))
-
-  elseif type == "expression_statement" then
-    local child = node:named_child(0)
-    local identifiers = {}
-    type = child:type()
-
-    if type == "assignment" then
-      -- handle multiple assignments, eg: x = y = z = 1
-      while child:type() == "assignment" do
-        table.insert(identifiers, helpers.node_text(child:named_child(0)))
-        child = child:named_child(1)
-      end
-
-      lhs = table.concat(identifiers, " = ") .. " = "
-      rhs = helpers.node_text(child)
-    elseif type == "call" then
-      lhs = helpers.node_text(child:named_child(0))
-      rhs = helpers.node_text(child:named_child(1))
-    end
- end
-
-  return lhs, rhs, type
-end
-
--- private
--- @param node tsnode
--- @param child_types string|table
--- @return boolean
-local function has_descendent_of_type(node, child_types)
-
-  if type(child_types) == "string" then
-    child_types = { [child_types] = true }
-  end
-
-  for i = 0, node:named_child_count() - 1 do
-    local child = node:named_child(i)
-
-    if child_types[child:type()] then
-      return true
-    end
-
-    if has_descendent_of_type(child, child_types) then
-      return true
-    end
-  end
-
-  return false
-end
-
--- The if/conditional_expression that we are expanding can find itself on
--- the same row as an inlined for or if statement.
--- For example:
---
--- `for x in range(10): x = 1 if x > 5 else x + 1`
--- `if x > 0: x = 1 if x > 5 else x + 1`
---
--- Contrived, hopefully, but this handles it, by detecting if there is a
--- for/if statement on the same row as our current parent.
---
--- private
--- @param parent tsnode
--- @param parent_type string
--- @param start_row number
--- @return tsnode, string
--- @return nil
-local function find_real_row_parent(parent, parent_type, start_row)
-
-  while parent ~= nil and
-    parent_type ~= "if_statement" and
-    parent_type ~= "for_statement" do
-    parent      = parent:parent()
-    parent_type = parent:type()
-    if select(1, parent:start()) ~= start_row then
-      return nil
-    end
-  end
-
-  if parent_type == "if_statement" or parent_type == "for_statement" then
-    return parent, parent_type
-  end
-
-  return nil
-end
-
--- We detect if it's safe to expand an inline if/else surrounded by parens
--- and remove them by skipping to it's parent, because the parent is
--- replaced by this action, with the expanded if/else.
---
--- Cases considered safe:
--- `x = (conditional_expression)`
--- `return (conditional_expression)`
---
--- @param parent tsnode
--- @param parent_type string
--- @return tsnode, string
-local function skip_parens_by_reparenting(parent, parent_type)
-  if parent_type == "parenthesized_expression" then
-    local paren_parent      = parent:parent()
-    local paren_parent_type = paren_parent:type()
-    if paren_parent_type == "assignment" or
-      paren_parent_type == "return_statement" then
-      parent      = paren_parent
-      parent_type = paren_parent_type
-    end
-  end
-  return parent, parent_type
-end
-
--- public
--- @param if_statement tsnode
--- @return string, table, tsnode
--- @return nil
-local function expand_if(conditional_expression)
-  local parent      = conditional_expression:parent()
-  local parent_type = parent:type()
-  local lhs
-  local cond_order = {1, 0, 2}
-
-  parent, parent_type = skip_parens_by_reparenting(parent, parent_type)
-
-  if parent_type == "return_statement" then
-    lhs = "return "
-  elseif parent_type == "assignment" then
-    local identifiers = {}
-    -- handle multiple assignments, eg: x = y = z = 1
-    while parent:type() == "assignment" do
-      table.insert(identifiers, 1, helpers.node_text(parent:named_child(0)))
-      parent = parent:parent()
-    end
-    lhs = table.concat(identifiers, " = ") .. " = "
-  elseif parent_type == "expression_statement" then
-    lhs = ""
-  elseif parent_type == "block" or parent_type == "module" then
-    lhs = ""
-    parent = conditional_expression
-    cond_order = {0, 1, 2}
-  else
-    return
-  end
-
-  local condition    = conditional_expression:named_child(cond_order[1])
-  local consequence  = conditional_expression:named_child(cond_order[2])
-  local alternative  = conditional_expression:named_child(cond_order[3])
-  local start_row, start_col = parent:start()
-  local row_parent = find_real_row_parent(parent, parent_type, start_row)
-  local cursor = {}
-  -- when we are embedded on the end of an inlined if/for statement, we need
-  -- to expand on to the next line and shift the cursor/indent
-  local if_indent   = ""
-  local else_indent = ""
-  if row_parent then
-    local _, row_start_col = row_parent:start()
-    -- cursor position is relative to the node being replaced (parent)
-    cursor    = { row = 1, col = row_start_col - start_col + 4  }
-    start_col = row_start_col + 4
-
-    if_indent   = string.rep(" ", row_start_col + 4)
-    else_indent = if_indent
-  else
-    else_indent = string.rep(" ", start_col)
-  end
-  local body_indent = else_indent .. string.rep(" ", 4)
-
-  local replacement = {
-    if_indent .. "if " .. helpers.node_text(condition) .. ":",
-    body_indent .. lhs .. helpers.node_text(consequence),
-  }
-
-  if alternative then
-    table.insert(replacement, else_indent .. "else:")
-    table.insert(replacement, body_indent .. lhs .. helpers.node_text(alternative))
-  end
-
-  if row_parent then
-    table.insert(replacement, 1, "")
-  end
-
-  return replacement, {
-    cursor = cursor,
-    format = false,
-    strip_whitespace = {},
-  }, parent
-end
-
--- private
--- @param if_statement tsnode
--- @return string, table, tsnode
--- @return nil
-local function inline_if(if_statement)
-  local condition   = if_statement:named_child(0)
-  local consequence = if_statement:named_child(1):named_child(0)
-  -- if there are siblings, return, b/c we can't inline multiple statements
-  if consequence:next_named_sibling() then
-    return
-  end
-
-  local lhs, rhs = node_text_lhs_rhs(consequence)
-  if lhs == nil then
-    return
-  elseif has_descendent_of_type(consequence, node_types_to_parenthesize) and
-    rhs:sub(1, 1) ~= "(" then
-    rhs = "(" .. rhs .. ")"
-  end
-
-  local parent_type = if_statement:parent():type()
-  local replacement
-  local cursor = {}
-
-  if parent_type == "block" or parent_type == "module" then
-    replacement = {
-      "if " .. helpers.node_text(condition) .. ": " .. lhs .. rhs
-    }
-  else
-    replacement = {
-      lhs .. rhs .. " if " .. helpers.node_text(condition) .. " else None"
-    }
-    cursor["col"] = string.len(lhs .. rhs) + 1
-  end
-
-  return replacement, { cursor = cursor, format = false }
-end
-
--- private
--- @param if_statement tsnode
--- @return string, table, tsnode
--- @return nil
-local function inline_ifelse(if_statement)
-  local condition   = if_statement:named_child(0)
-  local consequence = if_statement:named_child(1):named_child(0)
-  local alternative = if_statement:named_child(2):named_child(0):named_child(0)
-  -- if there are siblings, return, b/c we can't inline multiple statements
-  if consequence:next_named_sibling() or
-    alternative:next_named_sibling() then
-    return
-  end
-
-  local cons_lhs, cons_rhs, cons_type = node_text_lhs_rhs(consequence)
-  if cons_lhs == nil then
-    return
-  elseif has_descendent_of_type(consequence, node_types_to_parenthesize) and
-    cons_rhs:sub(1, 1) ~= "(" then
-    cons_rhs = "(" .. cons_rhs .. ")"
-  end
-
-  local alt_lhs, alt_rhs, alt_type = node_text_lhs_rhs(alternative)
-  if cons_type ~= alt_type or alt_rhs == nil then
-    return
-  elseif has_descendent_of_type(alternative, node_types_to_parenthesize) and
-    alt_rhs:sub(1, 1) ~= "(" then
-    alt_rhs = "(" .. alt_rhs .. ")"
-  end
-
-  local cond_text = helpers.node_text(condition)
-
-  local replacement = cons_lhs .. cons_rhs .. " if " .. cond_text .. " else "
-  if alt_type == "call" then
-    replacement = replacement .. alt_lhs .. alt_rhs
-  else
-    replacement = replacement .. alt_rhs
-  end
-
-  local cursor_col = string.len(cons_lhs .. cons_rhs) + 1
-
-  return replacement, { cursor = { col = cursor_col }, format = false }
-end
-
--- public
--- @param conditional_expression tsnode
--- @return string, table, tsnode
-local function inline_if_stmt(if_statement)
-  if helpers.multiline_node(if_statement) == false then
-    if if_statement:named_child_count() == 3 then
-      return inline_ifelse(if_statement)
-    elseif if_statement:named_child_count() == 2 then
-      return inline_if(if_statement)
-    end
-  else
-    return expand_if(if_statement)
-  end
-end
-
 -- Special cases:
 -- Because "is" and "not" are valid by themselves, they are seen as separate
 -- unnamed nodes by TS.  This means that without special handling, a config of:
@@ -371,6 +53,381 @@ local boolean_override = {
   ["False"] = "True",
 }
 
+
+-- When inlined, these nodes must be parenthesized to avoid changing the
+-- meaning of the code and to avoid syntax errors.
+-- eg: x = lambda y: y + 1 if y else 0
+--     x = (lambda y: y + 1) if y else 0
+-- Both are valid, but the first is not equivalent to the second.
+-- Unlike the second, the first can not be expanded to:
+--    if y:
+--        x = lambda y: y + 1
+--    else:
+--        x = 0
+-- because the if/else is part of the lambda expression.
+local node_types_to_parenthesize = {
+  ["conditional_expression"] = true,
+  ["lambda"] = true,
+}
+
+-- Recreating actions.toggle_multiline.collapse_child_nodes() here because
+-- it is not exported.  Maybe it could be a helper.  It was not possible to
+-- use helpers.node_text() on a multiline node because it will include the "\n",
+-- which is invalid for the replacement text.
+--
+-- @param node tsnode
+-- @return string
+local function collapse_child_nodes(padding_override)
+  local function action(node)
+    if helpers.multiline_node(node) then
+      return helpers.node_text(node)
+    end
+    local tbl = actions.toggle_multiline(padding_override)
+    local replacement = tbl[1][1](node)
+    return replacement
+  end
+  return action
+end
+
+-- Helper that returns the text of the left and right hand sides of a
+-- statement. For example, the left hand side of:
+--
+--  - `return 1` is `return` and the right hand side is `1`.
+--  - `x = 1` is `x = ` and the right hand side is `1`.
+--  - `x = y = z = 1` is `x = y = z = ` and the right hand side is `1`.
+--  - `print(3)` is `print` and the right hand side is `(3)`.
+--
+-- @param node tsnode
+-- @return string|nil, string|nil, string
+local function node_text_lhs_rhs(node, padding_override)
+  local lhs   = nil
+  local rhs   = nil
+  local type  = node:type()
+  local child = node:named_child(0)
+  local fn_collapse = collapse_child_nodes(padding_override)
+  if type == "return_statement" then
+    lhs = "return "
+    rhs = fn_collapse(child)
+
+  elseif type == "expression_statement" then
+    local identifiers = {}
+    type = child:type()
+
+    if type == "assignment" then
+      -- handle multiple assignments, eg: x = y = z = 1
+      while child:type() == "assignment" do
+        table.insert(identifiers, fn_collapse(child:named_child(0)))
+        child = child:named_child(1)
+      end
+
+      lhs = table.concat(identifiers, " = ") .. " = "
+      rhs = fn_collapse(child)
+    elseif type == "call" then
+      lhs   = fn_collapse(child:named_child(0))
+      child = child:named_child(1)
+      rhs   = fn_collapse(child)
+    elseif type == "boolean_operator" or
+           type == "parenthesized_expression" then
+      lhs = ""
+      rhs = fn_collapse(child)
+    end
+  end
+
+  return lhs, rhs, type, child
+end
+
+-- @param node tsnode
+-- @param child_types string|table
+-- @return boolean
+local function has_descendent_of_type(node, child_types)
+
+  if type(child_types) == "string" then
+    child_types = { [child_types] = true }
+  end
+
+  for i = 0, node:named_child_count() - 1 do
+    local child = node:named_child(i)
+
+    if child_types[child:type()] then
+      return true
+    end
+
+    if has_descendent_of_type(child, child_types) then
+      return true
+    end
+  end
+
+  return false
+end
+
+-- The if/conditional_expression that we are expanding can find itself on
+-- the same row as an inlined for or if statement.
+-- For example:
+--
+-- `for x in range(10): x = 1 if x > 5 else x + 1`
+-- `if x > 0: x = 1 if x > 5 else x + 1`
+--
+-- Contrived, hopefully, but this handles it, by detecting if there is a
+-- for/if statement on the same row as our current parent.
+--
+-- @param parent tsnode
+-- @param parent_type string
+-- @param start_row number
+-- @return tsnode, string
+-- @return nil
+local function find_real_row_parent(parent, parent_type, start_row)
+
+  while parent ~= nil and
+    parent_type ~= "if_statement" and
+    parent_type ~= "for_statement" do
+    parent      = parent:parent()
+    parent_type = parent:type()
+    if select(1, parent:start()) ~= start_row then
+      return nil
+    end
+  end
+
+  if parent_type == "if_statement" or parent_type == "for_statement" then
+    return parent, parent_type
+  end
+
+  return nil
+end
+
+-- We detect if it's safe to expand an inline if/else surrounded by parens
+-- and remove them by skipping to it's parent, because the parent is
+-- replaced by this action, with the expanded if/else.
+--
+-- Cases considered safe:
+-- `x = (conditional_expression)`
+-- `return (conditional_expression)`
+--
+-- @param parent tsnode
+-- @param parent_type string
+-- @return tsnode, string
+local function skip_parens_by_reparenting(parent, parent_type)
+  if parent_type == "parenthesized_expression" then
+    local paren_parent      = parent:parent()
+    local paren_parent_type = paren_parent:type()
+    if paren_parent_type == "assignment" or
+      paren_parent_type == "return_statement" then
+      parent      = paren_parent
+      parent_type = paren_parent_type
+    end
+  end
+  return parent, parent_type
+end
+
+-- @param if_statement tsnode
+-- @return string, table, tsnode
+-- @return nil
+local function expand_if(conditional_expression)
+  local parent      = conditional_expression:parent()
+  local parent_type = parent:type()
+  local cond_order  = {1, 0, 2}
+
+  parent, parent_type = skip_parens_by_reparenting(parent, parent_type)
+
+  local lhs
+  if parent_type == "return_statement" then
+    lhs = "return "
+  elseif parent_type == "assignment" then
+    local identifiers = {}
+    -- handle multiple assignments, eg: x = y = z = 1
+    while parent:type() == "assignment" do
+      table.insert(identifiers, 1, helpers.node_text(parent:named_child(0)))
+      parent = parent:parent()
+    end
+    lhs = table.concat(identifiers, " = ") .. " = "
+  elseif parent_type == "expression_statement" then
+    lhs = ""
+  elseif parent_type == "block" or parent_type == "module" then
+    lhs = ""
+    parent = conditional_expression
+    cond_order = {0, 1, 2}
+  else
+    return
+  end
+
+  local condition   = conditional_expression:named_child(cond_order[1])
+  local consequence = conditional_expression:named_child(cond_order[2])
+  local alternative = conditional_expression:named_child(cond_order[3])
+  local start_row, start_col = parent:start()
+  local row_parent = find_real_row_parent(parent, parent_type, start_row)
+  local cursor = {}
+  -- when we are embedded on the end of an inlined if/for statement, we need
+  -- to expand on to the next line and shift the cursor/indent
+  local if_indent   = ""
+  local else_indent = ""
+  if row_parent then
+    local _, row_start_col = row_parent:start()
+    -- cursor position is relative to the node being replaced (parent)
+    cursor      = { row = 1, col = row_start_col - start_col + 4  }
+    if_indent   = string.rep(" ", row_start_col + 4)
+    else_indent = if_indent
+  else
+    else_indent = string.rep(" ", start_col)
+  end
+  local body_indent = else_indent .. string.rep(" ", 4)
+
+  local replacement = {
+    if_indent .. "if " .. helpers.node_text(condition) .. ":",
+    body_indent .. lhs .. helpers.node_text(consequence),
+  }
+
+  if alternative then
+    table.insert(replacement, else_indent .. "else:")
+    table.insert(
+      replacement,
+      body_indent .. lhs .. helpers.node_text(alternative)
+    )
+  end
+
+  if row_parent then
+    table.insert(replacement, 1, "")
+  end
+
+  return replacement, { cursor = cursor, strip_whitespace = {},  }, parent
+end
+
+-- @param if_statement tsnode
+-- @param padding_override table
+-- @return string, table, tsnode
+-- @return nil
+local function inline_if(if_statement, padding_override)
+  local condition = if_statement:named_child(0)
+  local cons_expr = if_statement:named_child(1):named_child(0)
+  -- if there are siblings, return, b/c we can't inline multiple statements
+  if cons_expr:next_named_sibling() then
+    return
+  end
+
+  local lhs, rhs = node_text_lhs_rhs(cons_expr, padding_override)
+  if lhs == nil then
+    return
+  end
+  if has_descendent_of_type(cons_expr, node_types_to_parenthesize) and
+    rhs:sub(1, 1) ~= "(" then
+    rhs = "(" .. rhs .. ")"
+  end
+
+  local parent_type = if_statement:parent():type()
+  local replacement
+  local cursor = {}
+
+  local cond_text = collapse_child_nodes(padding_override)(condition)
+
+  if parent_type == "block" or parent_type == "module" then
+    replacement = { "if " .. cond_text .. ": " .. lhs .. rhs }
+  else
+    replacement = { lhs .. rhs .. " if " .. cond_text .. " else None" }
+    cursor["col"] = string.len(lhs .. rhs) + 1
+  end
+
+  return replacement, { cursor = cursor }
+end
+
+-- As long as there isn't an assignment or return on the left/right side,
+-- we can freely inline/expand these:
+local mixed_match_body_types = {
+  ["call"]                     = true,
+  ["boolean_operator"]         = true,
+  ["parenthesized_expression"] = true,
+}
+-- @param cons_type string
+-- @param alt_type string
+-- @return boolean
+local function compatible_body_types(cons_type, alt_type)
+  -- strict match
+  if cons_type == "assignment" or alt_type == "assignment" then
+    return cons_type == alt_type
+  elseif cons_type == "return_statement" or alt_type == "return_statement" then
+    return cons_type == alt_type
+  end
+
+  return mixed_match_body_types[cons_type] and
+         mixed_match_body_types[alt_type]
+end
+
+
+-- @param if_statement tsnode
+-- @param padding_override table
+-- @return string, table, tsnode
+-- @return nil
+local function inline_ifelse(if_statement, padding_override)
+  local condition = if_statement:named_child(0)
+  local cons_expr = if_statement:named_child(1):named_child(0)
+  local alt_expr  = if_statement:named_child(2):named_child(0):named_child(0)
+  -- if there are siblings, return, b/c we can't inline multiple statements
+  if cons_expr:next_named_sibling() or
+    alt_expr:next_named_sibling() then
+    return
+  end
+
+  local cons_lhs, cons_rhs, cons_type, cons_child = node_text_lhs_rhs(
+    cons_expr,
+    padding_override
+  )
+  if cons_lhs == nil then
+    return
+  end
+  if (has_descendent_of_type(cons_child, node_types_to_parenthesize) or
+    cons_type == "boolean_operator") and
+    cons_rhs:sub(1, 1) ~= "(" then
+    cons_rhs = "(" .. cons_rhs .. ")"
+  end
+
+  local alt_lhs, alt_rhs, alt_type, alt_child = node_text_lhs_rhs(
+    alt_expr,
+    padding_override
+  )
+  if not compatible_body_types(cons_type, alt_type) or alt_rhs == nil then
+    return
+  end
+  if (has_descendent_of_type(alt_expr, node_types_to_parenthesize) or
+    alt_type == "boolean_operator") and
+    alt_rhs:sub(1, 1) ~= "(" then
+    alt_rhs = "(" .. alt_rhs .. ")"
+  end
+
+  local cond_text = collapse_child_nodes(padding_override)(condition)
+
+  local replacement = cons_lhs .. cons_rhs .. " if " .. cond_text .. " else "
+  if alt_type == "call" then
+    replacement = replacement .. alt_lhs .. alt_rhs
+  else
+    replacement = replacement .. alt_rhs
+  end
+
+  local cursor_col = string.len(cons_lhs .. cons_rhs) + 1
+
+  return replacement, { cursor = { col = cursor_col } }
+end
+
+-- @param padding_override table
+-- @return function
+local function inline_if_stmt(padding_override)
+  padding_override = padding_override or padding
+
+  -- @param if_statement tsnode
+  -- @return string, table, tsnode
+  local function action(if_statement)
+    if helpers.multiline_node(if_statement) == false then
+      local fn
+      if if_statement:named_child_count() == 3 then
+        fn = inline_ifelse
+      elseif if_statement:named_child_count() == 2 then
+        fn = inline_if
+      end
+      return fn(if_statement, padding_override)
+    else
+      return expand_if(if_statement)
+    end
+  end
+
+  return action
+end
+
 return {
   ["dictionary"]               = actions.toggle_multiline(padding),
   ["set"]                      = actions.toggle_multiline(padding),
@@ -387,5 +444,5 @@ return {
   ["comparison_operator"]      = actions.toggle_operator(),
   ["integer"]                  = actions.toggle_int_readability(),
   ["conditional_expression"]   = { { expand_if, name = "Expand Conditional" } },
-  ["if_statement"]             = { { inline_if_stmt, name = "Inline Conditional" } },
+  ["if_statement"]             = { { inline_if_stmt(padding), name = "Inline Conditional" } },
 }

--- a/lua/ts-node-action/filetypes/python.lua
+++ b/lua/ts-node-action/filetypes/python.lua
@@ -452,9 +452,9 @@ local function inline_if_statement(padding_override)
         return
       end
       -- undecided on whether/how to inline if there are comments
-      if #struct.comments > 0 then
-        return
-      end
+      -- if #struct.comments > 0 then
+      --   return
+      -- end
 
       local fn
       if #struct.alternative ~= 0 then
@@ -484,9 +484,9 @@ local function expand_conditional_expression(padding_override)
   local function action(conditional_expression)
     local struct = destructure_conditional_expression(conditional_expression)
     -- undecided on whether/how to inline if there are comments
-    if #struct.comments > 0 then
-      return
-    end
+    -- if #struct.comments > 0 then
+    --   return
+    -- end
     return expand_cond_expr(struct, padding_override)
   end
 

--- a/lua/ts-node-action/filetypes/python.lua
+++ b/lua/ts-node-action/filetypes/python.lua
@@ -1,93 +1,224 @@
 local helpers = require("ts-node-action.helpers")
 local actions = require("ts-node-action.actions")
-local txt     = function(val) return helpers.node_text(val) end
 
+
+-- When inlined, these nodes must be parenthesized to avoid changing the
+-- meaning of the code and to avoid syntax errors.
+-- eg: x = lambda y: y + 1 if y else 0
+--     x = (lambda y: y + 1) if y else 0
+-- Both are valid, but the first is not equivalent to the second.
+-- Unlike the second, the first can not be expanded to:
+--    if y:
+--        x = lambda y: y + 1
+--    else:
+--        x = 0
+-- because the if/else is part of the lambda expression.
 -- private
--- @param block tsnode
+local node_types_to_parenthesize = {
+  ["conditional_expression"] = true,
+  ["lambda"] = true,
+}
+
+-- Helper that returns the text of the left and right hand sides of a
+-- statement. For example, the left hand side of:
+--
+--  - `return 1` is `return` and the right hand side is `1`.
+--  - `x = 1` is `x = ` and the right hand side is `1`.
+--  - `x = y = z = 1` is `x = y = z = ` and the right hand side is `1`.
+--
+-- private
+-- @param node tsnode
 -- @return string, string|nil
-local function block_text_lhs_rhs(block)
-  local lhs
-  local rhs
-  if block:type() == "return_statement" then
+local function node_text_lhs_rhs(node)
+  local lhs = nil
+  local rhs = nil
+
+  if node:type() == "return_statement" then
     lhs = "return "
-    rhs = txt(block:named_child(0))
-  elseif block:type() == "expression_statement" and
-         block:named_child(0):type() == "assignment" then
-    local assignment = block:named_child(0)
-    local identifier = assignment:named_child(0)
-    lhs = txt(identifier) .. " = "
-    rhs = txt(assignment:named_child(1))
-  else
-    return nil
+    rhs = helpers.node_text(node:named_child(0))
+  elseif node:type() == "expression_statement" then
+    local child = node:named_child(0)
+    local identifiers = {}
+
+    if child:type() == "assignment" then
+      -- handle multiple assignments, eg: x = y = z = 1
+      while child:type() == "assignment" do
+        table.insert(identifiers, helpers.node_text(child:named_child(0)))
+        child = child:named_child(1)
+      end
+
+      lhs = table.concat(identifiers, " = ") .. " = "
+      rhs = helpers.node_text(child)
+    elseif child:type() == "call" then
+      lhs = helpers.node_text(child:named_child(0))
+      rhs = helpers.node_text(child:named_child(1))
+    end
   end
+
   return lhs, rhs
 end
 
+-- private
+-- @param node tsnode
+-- @param child_types table
+-- @return boolean
+local function has_descendent_of_type(node, child_types)
+
+  for i = 0, node:named_child_count() - 1 do
+    local child = node:named_child(i)
+
+    if child_types[child:type()] then
+      return true
+    end
+
+    if has_descendent_of_type(child, child_types) then
+      return true
+    end
+  end
+
+  return false
+end
+
+-- private
+-- @param if_statement tsnode
+-- @return string, table, tsnode
+-- @return nil
 local function inline_if(if_statement)
   local condition   = if_statement:named_child(0)
   local consequence = if_statement:named_child(1):named_child(0)
-  local lhs, rhs = block_text_lhs_rhs(consequence)
+  local lhs, rhs    = node_text_lhs_rhs(consequence)
+
   if lhs == nil then
     return
+  elseif has_descendent_of_type(consequence, node_types_to_parenthesize) and
+    rhs:sub(1, 1) ~= "(" then
+    rhs = "(" .. rhs .. ")"
   end
-  local replacement = {
-    lhs .. rhs .. " if " .. txt(condition) .. " else None"
-  }
-  local cursor_col = string.len(lhs .. rhs) + 1
-  return replacement, { cursor = { col = cursor_col }, format = true }
+
+  local parent_type = if_statement:parent():type()
+  local replacement
+  local cursor = {}
+
+  if parent_type == "block" or parent_type == "module" then
+    replacement = {
+      "if " .. helpers.node_text(condition) .. ": " .. lhs .. rhs
+    }
+  else
+    replacement = {
+      lhs .. rhs .. " if " .. helpers.node_text(condition) .. " else None"
+    }
+    cursor["col"] = string.len(lhs .. rhs) + 1
+  end
+
+  return replacement, { cursor = cursor, format = true }
 end
 
+-- private
+-- @param if_statement tsnode
+-- @return string, table, tsnode
+-- @return nil
 local function inline_ifelse(if_statement)
   local condition   = if_statement:named_child(0)
   local consequence = if_statement:named_child(1):named_child(0)
   local alternative = if_statement:named_child(2):named_child(0):named_child(0)
-  local lhs, conseq_text = block_text_lhs_rhs(consequence)
+
+  local lhs, cons_text = node_text_lhs_rhs(consequence)
   if lhs == nil then
     return
+  elseif has_descendent_of_type(consequence, node_types_to_parenthesize) and
+    cons_text:sub(1, 1) ~= "(" then
+    cons_text = "(" .. cons_text .. ")"
   end
-  local lhs2, alter_text = block_text_lhs_rhs(alternative)
-  if lhs ~= lhs2 or alter_text == nil then
+
+  local lhs2, alt_text = node_text_lhs_rhs(alternative)
+  if lhs ~= lhs2 or alt_text == nil then
     return
+  elseif has_descendent_of_type(alternative, node_types_to_parenthesize) and
+    alt_text:sub(1, 1) ~= "(" then
+    alt_text = "(" .. alt_text .. ")"
   end
+
   local replacement = {
-    lhs .. conseq_text .. " if " .. txt(condition) .. " else " .. alter_text
+    lhs .. cons_text ..
+    " if " .. helpers.node_text(condition) ..
+    " else " .. alt_text
   }
-  local cursor_col = string.len(lhs .. conseq_text) + 1
+  local cursor_col = string.len(lhs .. cons_text) + 1
+
   return replacement, { cursor = { col = cursor_col }, format = true }
 end
 
-local function inline_if_stmt(if_statement)
-  if if_statement:named_child_count() == 3 then
-    return inline_ifelse(if_statement)
-  elseif if_statement:named_child_count() == 2 then
-    return inline_if(if_statement)
-  end
-end
-
+-- public
+-- @param if_statement tsnode
+-- @return string, table, tsnode
+-- @return nil
 local function expand_if(conditional_expression)
-  local parent       = conditional_expression:parent()
-  local parent_type  = parent:type()
-  local _, start_col = parent:start()
+  local parent      = conditional_expression:parent()
+  local parent_type = parent:type()
   local lhs
+  local cond_order = {1, 0, 2}
+
   if parent_type == "return_statement" then
     lhs = "return "
   elseif parent_type == "assignment" then
-    lhs = txt(parent:named_child(0)) .. " = "
+    local identifiers = {}
+
+    -- handle multiple assignments, eg: x = y = z = 1
+    while parent_type == "assignment" do
+      table.insert(
+        identifiers,
+        1,
+        helpers.node_text(parent:named_child(0))
+      )
+      parent = parent:parent()
+      parent_type = parent:type()
+    end
+
+    lhs = table.concat(identifiers, " = ") .. " = "
+  elseif parent_type == "expression_statement" then
+    lhs = ""
+  elseif parent_type == "block" or parent_type == "module" then
+    lhs = ""
+    parent = conditional_expression
+    cond_order = {0, 1, 2}
   else
     return
   end
-  local condition   = conditional_expression:named_child(1)
-  local consequence = conditional_expression:named_child(0)
-  local alternative = conditional_expression:named_child(2)
-  local else_indent = string.rep(" ", start_col)
-  local body_indent = else_indent .. string.rep(" ", 4)
-  local replacement = {
-    "if " .. txt(condition) .. ":",
-    body_indent .. lhs .. txt(consequence),
-    else_indent .. "else:",
-    body_indent .. lhs .. txt(alternative),
+
+  local condition    = conditional_expression:named_child(cond_order[1])
+  local consequence  = conditional_expression:named_child(cond_order[2])
+  local alternative  = conditional_expression:named_child(cond_order[3])
+  local _, start_col = parent:start()
+  local else_indent  = string.rep(" ", start_col)
+  local body_indent  = else_indent .. string.rep(" ", 4)
+  local replacement  = {
+    "if " .. helpers.node_text(condition) .. ":",
+    body_indent .. lhs .. helpers.node_text(consequence),
   }
+  if alternative and
+    (alternative:type() ~= "none" or parent_type ~= "expression_statement") then
+    table.insert(replacement, else_indent .. "else:")
+    table.insert(
+      replacement,
+      body_indent .. lhs .. helpers.node_text(alternative)
+    )
+  end
   return replacement, { cursor = {}, format = true }, parent
+end
+
+-- public
+-- @param conditional_expression tsnode
+-- @return string, table, tsnode
+local function inline_if_stmt(if_statement)
+  if helpers.multiline_node(if_statement) == false then
+    if if_statement:named_child_count() == 3 then
+      return inline_ifelse(if_statement)
+    elseif if_statement:named_child_count() == 2 then
+      return inline_if(if_statement)
+    end
+  else
+    return expand_if(if_statement)
+  end
 end
 
 -- Special cases:
@@ -156,6 +287,6 @@ return {
   ["true"]                     = actions.toggle_boolean(boolean_override),
   ["false"]                    = actions.toggle_boolean(boolean_override),
   ["comparison_operator"]      = actions.toggle_operator(),
-  ["conditional_expression"]   = { { expand_if, name = "Expand If Stmt" } },
-  ["if_statement"]             = { { inline_if_stmt, name = "Inline If Stmt" } },
+  ["conditional_expression"]   = { { expand_if, name = "Expand Ternary" } },
+  ["if_statement"]             = { { inline_if_stmt, name = "Inline If/Else" } },
 }

--- a/lua/ts-node-action/filetypes/python.lua
+++ b/lua/ts-node-action/filetypes/python.lua
@@ -378,7 +378,8 @@ local function expand_cond_expr(stmt, padding_override)
     cursor   = cursor,
     callback = callback,
     format   = true,
-  }, parent
+    target   = parent,
+  }
 end
 
 -- @param stmt table { node, condition, consequence, alternative, comments }

--- a/lua/ts-node-action/filetypes/python.lua
+++ b/lua/ts-node-action/filetypes/python.lua
@@ -186,22 +186,28 @@ local function expand_if(conditional_expression)
   local cursor = {}
   -- when we are embedded on the end of an inlined if/for statement, we need
   -- to expand on to the next line and shift the cursor/indent
+  local if_indent   = ""
+  local else_indent = ""
   if row_parent then
     local _, row_start_col = row_parent:start()
     -- cursor position is relative to the node being replaced (parent)
-    cursor = { row = 1, col = row_start_col - start_col + 4  }
+    cursor    = { row = 1, col = row_start_col - start_col + 4  }
     start_col = row_start_col + 4
+
+    if_indent   = string.rep(" ", row_start_col + 4)
+    else_indent = if_indent
+  else
+    else_indent = string.rep(" ", start_col)
   end
-  local ifelse_indent = string.rep(" ", start_col)
-  local body_indent   = ifelse_indent .. string.rep(" ", 4)
+  local body_indent = else_indent .. string.rep(" ", 4)
 
   local replacement = {
-    ifelse_indent .. "if " .. helpers.node_text(condition) .. ":",
+    if_indent .. "if " .. helpers.node_text(condition) .. ":",
     body_indent .. lhs .. helpers.node_text(consequence),
   }
 
   if alternative then
-    table.insert(replacement, ifelse_indent .. "else:")
+    table.insert(replacement, else_indent .. "else:")
     table.insert(replacement, body_indent .. lhs .. helpers.node_text(alternative))
   end
 
@@ -211,7 +217,7 @@ local function expand_if(conditional_expression)
 
   return replacement, {
     cursor = cursor,
-    format = true,
+    format = false,
     strip_whitespace = {},
   }, parent
 end
@@ -251,7 +257,7 @@ local function inline_if(if_statement)
     cursor["col"] = string.len(lhs .. rhs) + 1
   end
 
-  return replacement, { cursor = cursor, format = true }
+  return replacement, { cursor = cursor, format = false }
 end
 
 -- private
@@ -295,7 +301,7 @@ local function inline_ifelse(if_statement)
 
   local cursor_col = string.len(cons_lhs .. cons_rhs) + 1
 
-  return replacement, { cursor = { col = cursor_col }, format = true }
+  return replacement, { cursor = { col = cursor_col }, format = false }
 end
 
 -- public

--- a/lua/ts-node-action/helpers.lua
+++ b/lua/ts-node-action/helpers.lua
@@ -47,7 +47,7 @@ end
 -- The ["is"] key under "not" overrides the format to remove the space when the
 -- previous text is "is".
 -- A [""] key is a catch-all for any non-nil prev_text.
--- A ["nil"] key will match when prev_text = nil.
+-- A ["nil"] key will match when prev_text == nil.
 -- See filetypes/python.lua for more info.
 --
 -- @param node tsnode

--- a/lua/ts-node-action/helpers.lua
+++ b/lua/ts-node-action/helpers.lua
@@ -28,8 +28,8 @@ function M.node_is_multiline(node)
 end
 
 -- Adds whitespace to some unnamed nodes for nicer formatting
--- `padding` is a table where the key is the text of the unnamed node, and the value
--- is a format string. The following would add a space after commas:
+-- `padding` is a table where the key is the text of the unnamed node, and the
+-- value is a format string. The following would add a space after commas:
 -- { [","] = "%s " }
 --
 -- The prev_text is used for rare cases where the padding of an unnamed node
@@ -52,27 +52,27 @@ end
 --
 -- @param node tsnode
 -- @param padding table
--- @param prev_text string|nil The [presumed padded] text of the previous node.
+-- @param context string|nil The [presumed padded] text of the previous node.
 -- @return string
-function M.padded_node_text(node, padding, prev_text)
+function M.padded_node_text(node, padding, context)
   local text = M.node_text(node)
 
   if padding[text] then
-    local cfg = padding[text]
+    local format = padding[text]
 
-    if type(cfg) == "table" then
-      prev_text = prev_text and vim.trim(prev_text)
+    if type(format) == "table" then
+      context = context and vim.trim(context)
 
-      if cfg[prev_text] then
-        text = string.format(cfg[prev_text], text)
-      elseif cfg["nil"] and prev_text == nil then
-        text = string.format(cfg["nil"], text)
-      elseif cfg[""] then
-        text = string.format(cfg[""], text)
+      if format[context] then
+        text = string.format(format[context], text)
+      elseif format["nil"] and context == nil then
+        text = string.format(format["nil"], text)
+      elseif format[""] then
+        text = string.format(format[""], text)
       end
 
     else
-      text = string.format(cfg, text)
+      text = string.format(format, text)
     end
   end
 

--- a/lua/ts-node-action/init.lua
+++ b/lua/ts-node-action/init.lua
@@ -19,6 +19,15 @@ local function replace_node(node, replacement, opts)
     start_row, start_col, end_row, end_col, replacement
   )
 
+  if opts.whitespace then
+    vim.cmd(
+      "silent! " ..
+      (start_row + (opts.whitespace.start_row or 0)) .. "," ..
+      (end_row   + (opts.whitespace.end_row   or 1)) ..
+      "s/\\s\\+$//g"
+    )
+  end
+
   if opts.cursor then
     vim.api.nvim_win_set_cursor(
       vim.api.nvim_get_current_win(),
@@ -50,9 +59,9 @@ end
 -- @param node tsnode
 -- @return nil
 local function do_action(action, node)
-  local replacement, opts, start_node = action(node)
+  local replacement, opts, target_node = action(node)
   if replacement then
-    replace_node(start_node or node, replacement, opts or {})
+    replace_node(target_node or node, replacement, opts or {})
   else
     info("Action returned nil")
   end

--- a/lua/ts-node-action/init.lua
+++ b/lua/ts-node-action/init.lua
@@ -19,11 +19,11 @@ local function replace_node(node, replacement, opts)
     start_row, start_col, end_row, end_col, replacement
   )
 
-  if opts.strip_whitespace then
+  if opts.trim_whitespace then
     vim.cmd(
       "silent! keeppatterns " ..
-      (start_row + (opts.strip_whitespace.start_row or 1)) .. "," ..
-      (end_row   + (opts.strip_whitespace.end_row   or 2)) ..
+      (start_row + (opts.trim_whitespace.start_row or 1)) .. "," ..
+      (end_row   + (opts.trim_whitespace.end_row   or 2)) ..
       "s/\\s\\+$//g"
     )
   end

--- a/lua/ts-node-action/init.lua
+++ b/lua/ts-node-action/init.lua
@@ -50,9 +50,9 @@ end
 -- @param node tsnode
 -- @return nil
 local function do_action(action, node)
-  local replacement, opts = action(node)
+  local replacement, opts, start_node = action(node)
   if replacement then
-    replace_node(node, replacement, opts or {})
+    replace_node(start_node or node, replacement, opts or {})
   else
     info("Action returned nil")
   end

--- a/lua/ts-node-action/init.lua
+++ b/lua/ts-node-action/init.lua
@@ -13,7 +13,8 @@ local function replace_node(node, replacement, opts)
     replacement = { replacement }
   end
 
-  local start_row, start_col, end_row, end_col = node:range()
+  local target = opts.target or node
+  local start_row, start_col, end_row, end_col = target:range()
   vim.api.nvim_buf_set_text(
     vim.api.nvim_get_current_buf(),
     start_row, start_col, end_row, end_col, replacement
@@ -50,9 +51,9 @@ end
 -- @param node tsnode
 -- @return nil
 local function do_action(action, node)
-  local replacement, opts, target_node = action(node)
+  local replacement, opts = action(node)
   if replacement then
-    replace_node(target_node or node, replacement, opts or {})
+    replace_node(node, replacement, opts or {})
   else
     info("Action returned nil")
   end

--- a/lua/ts-node-action/init.lua
+++ b/lua/ts-node-action/init.lua
@@ -19,11 +19,11 @@ local function replace_node(node, replacement, opts)
     start_row, start_col, end_row, end_col, replacement
   )
 
-  if opts.whitespace then
+  if opts.strip_whitespace then
     vim.cmd(
-      "silent! " ..
-      (start_row + (opts.whitespace.start_row or 0)) .. "," ..
-      (end_row   + (opts.whitespace.end_row   or 1)) ..
+      "silent! keeppatterns " ..
+      (start_row + (opts.strip_whitespace.start_row or 1)) .. "," ..
+      (end_row   + (opts.strip_whitespace.end_row   or 2)) ..
       "s/\\s\\+$//g"
     )
   end

--- a/lua/ts-node-action/init.lua
+++ b/lua/ts-node-action/init.lua
@@ -19,15 +19,6 @@ local function replace_node(node, replacement, opts)
     start_row, start_col, end_row, end_col, replacement
   )
 
-  if opts.trim_whitespace then
-    vim.cmd(
-      "silent! keeppatterns " ..
-      (start_row + (opts.trim_whitespace.start_row or 1)) .. "," ..
-      (end_row   + (opts.trim_whitespace.end_row   or 2)) ..
-      "s/\\s\\+$//g"
-    )
-  end
-
   if opts.cursor then
     vim.api.nvim_win_set_cursor(
       vim.api.nvim_get_current_win(),

--- a/spec/filetypes/python/conditional_expression_spec.lua
+++ b/spec/filetypes/python/conditional_expression_spec.lua
@@ -167,7 +167,7 @@ describe("conditional_expression", function()
     )
   end)
 
-  it("expand a multiline expr with comments", function()
+  it("expands a multiline expr with trailing comment", function()
     assert.are.same(
       {
         [[if foo(x, y):]],
@@ -177,21 +177,38 @@ describe("conditional_expression", function()
       },
       Helper:call(
         {
-          [[return [ # a]],
-          [[    3, # b]],
-          [[    4, # c]],
-          [[    5 # d]],
-          [[] if foo(x, # e]],
-          [[         y) else { # f]],
-          [[    4, # g]],
-          [[    5, # h]],
-          [[    6 # i]],
+          [[return []],
+          [[    3,]],
+          [[    4,]],
+          [[    5]],
+          [[] if foo(x,]],
+          [[         y) else {]],
+          [[    4,]],
+          [[    5,]],
+          [[    6]],
           [[} # j]],
         },
         { 5, 3 }
       )
     )
   end)
+
+  it("doesn't expand a multiline expr with embedded comments", function()
+    local text = {
+      [[return [ # a]],
+      [[    3, # b]],
+      [[    4, # c]],
+      [[    5 # d]],
+      [[] if foo(x, # e]],
+      [[         y) else { # f]],
+      [[    4, # g]],
+      [[    5, # h]],
+      [[    6 # i]],
+      [[}]],
+    }
+    assert.are.same(text, Helper:call(text, { 5, 3 }))
+  end)
+
 
   it("doesn't expand a condition inside a fn call", function()
     local text = {

--- a/spec/filetypes/python/conditional_expression_spec.lua
+++ b/spec/filetypes/python/conditional_expression_spec.lua
@@ -89,6 +89,38 @@ describe("conditional_expression", function()
     )
   end)
 
+  it("expands when after a for_statement", function()
+    assert.are.same(
+      {
+        [[for x in range(10):]],
+        [[    if x % 2 == 0:]],
+        [[        print(x)]],
+        [[    else:]],
+        [[        print(x + 1)]],
+      },
+      Helper:call(
+        { [[for x in range(10): print(x) if x % 2 == 0 else print(x + 1)]] },
+        { 1, 30 }
+      )
+    )
+  end)
+
+  it("expands when after an if_statement", function()
+    assert.are.same(
+      {
+        [[if x % 2 == 0:]],
+        [[    if x > 10:]],
+        [[        print(x)]],
+        [[    else:]],
+        [[        print(x + 1)]],
+      },
+      Helper:call(
+        { [[if x % 2 == 0: print(x) if x > 10 else print(x + 1)]] },
+        { 1, 25 }
+      )
+    )
+  end)
+
   it("expands with multiline parenthesized_expression", function()
     assert.are.same(
       {
@@ -133,6 +165,50 @@ describe("conditional_expression", function()
         { 5, 3 }
       )
     )
+  end)
+
+  it("doesn't expand a multiline expr with comments", function()
+    local text = {
+      [[return [ # a]],
+      [[    3, # b]],
+      [[    4, # c]],
+      [[    5 # d]],
+      [[] if foo(x, # e]],
+      [[         y) else { # f]],
+      [[    4, # g]],
+      [[    5, # h]],
+      [[    6 # i]],
+      [[} # j]],
+    }
+    assert.are.same(text, text, { 5, 3 })
+  end)
+
+  it("doesn't expand a condition inside a fn call", function()
+    local text = {
+      [[foo("param1", 4 if foo() > 100 else 5)]],
+    }
+    assert.are.same(text, Helper:call(text, { 1, 17 }))
+  end)
+
+  it("doesn't expand a condition inside a lambda inside a fn call", function()
+    local text = {
+      [[foo("param1", lambda x: 4 if foo() > 100 else 5)]],
+    }
+    assert.are.same(text, Helper:call(text, { 1, 26 }))
+  end)
+
+  it("doesn't expand inside a list comprehension", function()
+    local text = {
+      [[foo([x for x in range(10) if x % 2 == 0])]],
+    }
+    assert.are.same(text, Helper:call(text, { 1, 27 }))
+  end)
+
+  it("doesn't expand inside a list", function()
+    local text = {
+      [=[return [0, 123 if foo() > 100 else 456]]=],
+    }
+    assert.are.same(text, Helper:call(text, { 1, 16 }))
   end)
 
 end)

--- a/spec/filetypes/python/conditional_expression_spec.lua
+++ b/spec/filetypes/python/conditional_expression_spec.lua
@@ -167,20 +167,30 @@ describe("conditional_expression", function()
     )
   end)
 
-  it("doesn't expand a multiline expr with comments", function()
-    local text = {
-      [[return [ # a]],
-      [[    3, # b]],
-      [[    4, # c]],
-      [[    5 # d]],
-      [[] if foo(x, # e]],
-      [[         y) else { # f]],
-      [[    4, # g]],
-      [[    5, # h]],
-      [[    6 # i]],
-      [[} # j]],
-    }
-    assert.are.same(text, text, { 5, 3 })
+  it("expand a multiline expr with comments", function()
+    assert.are.same(
+      {
+        [[if foo(x, y):]],
+        [=[    return [3, 4, 5]]=],
+        [[else:]],
+        [[    return {4, 5, 6} # j]],
+      },
+      Helper:call(
+        {
+          [[return [ # a]],
+          [[    3, # b]],
+          [[    4, # c]],
+          [[    5 # d]],
+          [[] if foo(x, # e]],
+          [[         y) else { # f]],
+          [[    4, # g]],
+          [[    5, # h]],
+          [[    6 # i]],
+          [[} # j]],
+        },
+        { 5, 3 }
+      )
+    )
   end)
 
   it("doesn't expand a condition inside a fn call", function()

--- a/spec/filetypes/python/conditional_expression_spec.lua
+++ b/spec/filetypes/python/conditional_expression_spec.lua
@@ -1,0 +1,138 @@
+dofile("./spec/spec_helper.lua")
+
+local Helper = SpecHelper:new("python")
+
+describe("conditional_expression", function()
+
+  it("expands with a single assignment", function()
+    assert.are.same(
+      {
+        [[if foo(y):]],
+        [[    x = 1]],
+        [[else:]],
+        [[    x = 2]],
+      },
+      Helper:call({ [[x = 1 if foo(y) else 2]] }, { 1, 7 })
+    )
+  end)
+
+  it("expands with a multi assignment", function()
+    assert.are.same(
+      {
+        [[if foo(y):]],
+        [[    x = y = z = 1]],
+        [[else:]],
+        [[    x = y = z = 2]],
+      },
+      Helper:call({ [[x = y = z = 1 if foo(y) else 2]] }, { 1, 15 })
+    )
+  end)
+
+  it("expands with a return", function()
+    assert.are.same(
+      {
+        [[if foo(y):]],
+        [[    return 1]],
+        [[else:]],
+        [[    return 2]],
+      },
+      Helper:call({ [[return 1 if foo(y) else 2]] }, { 1, 10 })
+    )
+  end)
+
+  it("expands with function calls", function()
+    assert.are.same(
+      {
+        [[if foo(y):]],
+        [[    bar()]],
+        [[else:]],
+        [[    baz()]],
+      },
+      Helper:call({ [[bar() if foo(y) else baz()]] }, { 1, 7 })
+    )
+  end)
+
+  it("expands with both parenthesized lambda expr", function()
+    assert.are.same(
+      {
+        [[if z is not None:]],
+        [[    x = (lambda y: y + 1)]],
+        [[else:]],
+        [[    x = (lambda y: y - 1)]],
+      },
+      Helper:call(
+        { [[x = (lambda y: y + 1) if z is not None else (lambda y: y - 1)]] },
+        { 1, 23 }
+      )
+    )
+  end)
+
+  it("doesn't expand with a bare consequence lambda expr ('if' is inside lambda)", function()
+    local text = {
+      [[x = lambda y: y + 1 if z is not None else lambda y: y - 1]]
+    }
+    assert.are.same(text, Helper:call(text, { 1, 23 }))
+  end)
+
+  it("expands with a parenthesized consequence lambda expr", function()
+    assert.are.same(
+      {
+        [[if z is not None:]],
+        [[    x = (lambda y: y + 1)]],
+        [[else:]],
+        [[    x = lambda y: y - 1]],
+      },
+      Helper:call(
+        { [[x = (lambda y: y + 1) if z is not None else lambda y: y - 1]] },
+        { 1, 23 }
+      )
+    )
+  end)
+
+  it("expands with multiline parenthesized_expression", function()
+    assert.are.same(
+      {
+        [[if (foo() > 100 or foo() < 200):]],
+        [[    y = x = (1 or 3)]],
+        [[else:]],
+        [[    y = x = (2 or 4)]],
+      },
+      Helper:call(
+        {
+          [[y = x = (1 or]],
+          [[         3) if (foo() > 100 or]],
+          [[                foo() < 200) else (2 or]],
+          [[                                   4)]],
+        },
+        { 2, 13 }
+      )
+    )
+  end)
+
+  it("expands with multiline structures and fn args", function()
+    assert.are.same(
+      {
+        [[if foo(x, y):]],
+        [=[    return [3, 4, 5]]=],
+        [[else:]],
+        [[    return {4, 5, 6}]],
+      },
+      Helper:call(
+        {
+          [[return []],
+          [[    3,]],
+          [[    4,]],
+          [[    5]],
+          [[] if foo(x,]],
+          [[         y) else {]],
+          [[    4,]],
+          [[    5,]],
+          [[    6]],
+          [[}]],
+        },
+        { 5, 3 }
+      )
+    )
+  end)
+
+end)

--- a/spec/filetypes/python/if_statement_spec.lua
+++ b/spec/filetypes/python/if_statement_spec.lua
@@ -142,4 +142,128 @@ describe("if_statement", function()
     )
   end)
 
+  it("if inlines with a single assignment", function()
+    assert.are.same(
+      { [[if foo(y): x = 1]] },
+      Helper:call({
+        [[if foo(y):]],
+        [[    x = 1]],
+      })
+    )
+  end)
+
+  it("if inlines with a multi assignment", function()
+    assert.are.same(
+      { [[if foo(a): x = y = z = 1]] },
+      Helper:call({
+        [[if foo(a):]],
+        [[    x = y = z = 1]],
+      })
+    )
+  end)
+
+  it("if inlines with a return", function()
+    assert.are.same(
+      { [[if foo(y): return 1]] },
+      Helper:call({
+        [[if foo(y):]],
+        [[    return 1]],
+      })
+    )
+  end)
+
+  it("if inlines with function calls", function()
+    assert.are.same(
+      { [[if foo(y): bar()]] },
+      Helper:call({
+        [[if foo(y):]],
+        [[    bar()]],
+      })
+    )
+  end)
+
+  it("if expands with a single assignment", function()
+    assert.are.same(
+      {
+        [[if foo(y):]],
+        [[    x = 1]],
+      },
+      Helper:call({
+        [[if foo(y): x = 1]],
+      })
+    )
+  end)
+
+  it("if expands with a multi assignment", function()
+    assert.are.same(
+      {
+        [[if foo(a):]],
+        [[    x = y = z = 1]],
+      },
+      Helper:call({
+        [[if foo(a): x = y = z = 1]],
+      })
+    )
+  end)
+
+  it("if expands with a return", function()
+    assert.are.same(
+      {
+        [[if foo(y):]],
+        [[    return 1]],
+      },
+      Helper:call({
+        [[if foo(y): return 1]],
+      })
+    )
+  end)
+
+  it("if expands with function calls", function()
+    assert.are.same(
+      {
+        [[if foo(y):]],
+        [[    bar()]],
+      },
+      Helper:call({
+        [[if foo(y): bar()]],
+      })
+    )
+  end)
+
+  it("if/else doesn't expand when there are comments", function()
+    assert.are.same(
+      {
+        [[if foo(y):]],
+        [[    # comment]],
+        [[    x = 1]],
+        [[else:]],
+        [[    # comment]],
+        [[    x = 2]],
+      },
+      Helper:call({
+        [[if foo(y):]],
+        [[    # comment]],
+        [[    x = 1]],
+        [[else:]],
+        [[    # comment]],
+        [[    x = 2]],
+      })
+    )
+  end)
+
+  it("if doesn't expand when there are comments", function()
+    assert.are.same(
+      {
+        [[if foo(y):]],
+        [[    # comment]],
+        [[    x = 1]],
+      },
+      Helper:call({
+        [[if foo(y):]],
+        [[    # comment]],
+        [[    x = 1]],
+      })
+    )
+  end)
+
 end)

--- a/spec/filetypes/python/if_statement_spec.lua
+++ b/spec/filetypes/python/if_statement_spec.lua
@@ -1,0 +1,145 @@
+dofile("./spec/spec_helper.lua")
+
+local Helper = SpecHelper:new("python")
+
+describe("if_statement", function()
+
+  it("if/else inlines with a single assignment", function()
+    assert.are.same(
+      { [[x = 1 if foo(y) else 2]] },
+      Helper:call({
+        [[if foo(y):]],
+        [[    x = 1]],
+        [[else:]],
+        [[    x = 2]],
+      })
+    )
+  end)
+
+  it("if/else inlines with a multi assignment", function()
+    assert.are.same(
+      { [[x = y = z = 1 if foo(a) else 2]] },
+      Helper:call({
+        [[if foo(a):]],
+        [[    x = y = z = 1]],
+        [[else:]],
+        [[    x = y = z = 2]],
+      })
+    )
+  end)
+
+  it("if/else doesn't inline a multi assignment when identifiers differ (consequence)", function()
+    local text = {
+      [[if foo(a):]],
+      [[    c = y = z = 1]],
+      [[else:]],
+      [[    x = y = z = 2]],
+    }
+    assert.are.same(text, text)
+  end)
+
+  it("if/else doesn't inline a multi assignment when identifiers differ (alternative)", function()
+    local text = {
+      [[if foo(a):]],
+      [[    x = y = z = 1]],
+      [[else:]],
+      [[    x = y = c = 2]],
+    }
+    assert.are.same(text, text)
+  end)
+
+
+  it("if/else inlines with a return", function()
+    assert.are.same(
+      { [[return 1 if foo(y) else 2]] },
+      Helper:call({
+        [[if foo(y):]],
+        [[    return 1]],
+        [[else:]],
+        [[    return 2]],
+      })
+    )
+  end)
+
+  it("if/else inlines with function calls", function()
+    assert.are.same(
+      { [[bar() if foo(y) else baz()]] },
+      Helper:call({
+        [[if foo(y):]],
+        [[    bar()]],
+        [[else:]],
+        [[    baz()]],
+      })
+    )
+  end)
+
+  it("if/else inlines with parenthesized lambda expr", function()
+    assert.are.same(
+      { [[x = (lambda y: y + 1) if z is not None else (lambda y: y - 1)]] },
+      Helper:call({
+        [[if z is not None:]],
+        [[    x = (lambda y: y + 1)]],
+        [[else:]],
+        [[    x = (lambda y: y - 1)]],
+      })
+    )
+  end)
+
+  it("if/else inlines with bare lambda expr (auto parens)", function()
+    assert.are.same(
+      { [[x = (lambda y: y + 3) if z is not None else (lambda y: y - 4)]] },
+      Helper:call({
+        [[if z is not None:]],
+        [[    x = lambda y: y + 3]],
+        [[else:]],
+        [[    x = lambda y: y - 4]],
+      })
+    )
+  end)
+
+  it("if/else inlines with bare boolean_operator (auto parens)", function()
+    assert.are.same(
+      { [[x = (a or b) if z is not None else (c or d)]] },
+      Helper:call({
+        [[if z is not None:]],
+        [[    x = a or b]],
+        [[else:]],
+        [[    x = c or d]],
+      })
+    )
+  end)
+
+  it("if/else inlines with bare conditional_expression (auto parens)", function()
+    assert.are.same(
+      { [[x = (3 if a else 4) if z is not None else (5 if b else 6)]] },
+      Helper:call({
+        [[if z is not None:]],
+        [[    x = 3 if a else 4]],
+        [[else:]],
+        [[    x = 5 if b else 6]],
+      })
+    )
+  end)
+
+  it("if/else inlines with multiline parenthized fn args, boolean op, structures", function()
+    assert.are.same(
+      {
+        [=[y = x = [1, 3] if (foo(a, b) > 100 or foo(c, d) < 200) else (False or True)]=]
+      },
+      Helper:call(
+        {
+          [[if (foo(a,]],
+          [[        b) > 100 or]],
+          [[    foo(c,]],
+          [[        d) < 200):]],
+          [[    y = x = [1,]],
+          [=[             3]]=],
+          [[else:]],
+          [[    y = x = (False or]],
+          [[             True)]],
+        }
+      )
+    )
+  end)
+
+end)

--- a/spec/filetypes/python/if_statement_spec.lua
+++ b/spec/filetypes/python/if_statement_spec.lua
@@ -230,15 +230,10 @@ describe("if_statement", function()
     )
   end)
 
-  it("if/else doesn't expand when there are comments", function()
+  it("if/else inlines even when there are comments", function()
     assert.are.same(
       {
-        [[if foo(y):]],
-        [[    # comment]],
-        [[    x = 1]],
-        [[else:]],
-        [[    # comment]],
-        [[    x = 2]],
+        [[x = 1 if foo(y) else 2]],
       },
       Helper:call({
         [[if foo(y):]],
@@ -251,17 +246,15 @@ describe("if_statement", function()
     )
   end)
 
-  it("if doesn't expand when there are comments", function()
+  it("if inlines even when there are comments", function()
     assert.are.same(
       {
-        [[if foo(y):]],
-        [[    # comment]],
-        [[    x = 1]],
+        [[if foo(y): x = 1 # c]],
       },
       Helper:call({
-        [[if foo(y):]],
-        [[    # comment]],
-        [[    x = 1]],
+        [[if foo(y): # a]],
+        [[    # b]],
+        [[    x = 1 # c]],
       })
     )
   end)

--- a/spec/filetypes/python/if_statement_spec.lua
+++ b/spec/filetypes/python/if_statement_spec.lua
@@ -230,33 +230,25 @@ describe("if_statement", function()
     )
   end)
 
-  it("if/else inlines even when there are comments", function()
-    assert.are.same(
-      {
-        [[x = 1 if foo(y) else 2]],
-      },
-      Helper:call({
-        [[if foo(y):]],
-        [[    # comment]],
-        [[    x = 1]],
-        [[else:]],
-        [[    # comment]],
-        [[    x = 2]],
-      })
-    )
+  it("if/else doesn't inline when there are comments", function()
+    local text = {
+      [[if foo(y):]],
+      [[    # comment]],
+      [[    x = 1]],
+      [[else:]],
+      [[    # comment]],
+      [[    x = 2]]
+    }
+    assert.are.same(text, Helper:call(text))
   end)
 
-  it("if inlines even when there are comments", function()
-    assert.are.same(
-      {
-        [[if foo(y): x = 1 # c]],
-      },
-      Helper:call({
-        [[if foo(y): # a]],
-        [[    # b]],
-        [[    x = 1 # c]],
-      })
-    )
+  it("if doesn't inline when there are comments", function()
+    local text = {
+      [[if foo(y):]],
+      [[    # comment]],
+      [[    x = 1]],
+    }
+    assert.are.same(text, Helper:call(text))
   end)
 
 end)

--- a/spec/filetypes/ruby_spec.lua
+++ b/spec/filetypes/ruby_spec.lua
@@ -219,10 +219,8 @@ describe("array", function()
     )
   end)
 
-  it("collapses multi-line array and skips embedded comments", function()
-    assert.are.same(
-      { "[1, 2, 3]" },
-      Helper:call({
+  it("doesn't collapse multi-line array with embedded comments", function()
+    local text = {
         "[ # a",
         "  1, # b",
         "  2, # c",
@@ -232,29 +230,27 @@ describe("array", function()
         "=end",
         "  3 # d",
         "]"
-      })
-    )
+      }
+    assert.are.same(text, Helper:call(text))
   end)
 
-  it("collapses child arrays and skips embedded comments", function()
-    assert.are.same(
-      { "[1, 2, [3, 4, 5]]" },
-      Helper:call({
-        "[",
-        "  1,",
-        "  2,",
-        "  [ # a",
-        "    3, # b",
-        "    4, # c",
-        "=begin",
-        "a multiline comment here",
-        "and one more line",
-        "=end",
-        "    5 # d",
-        "  ]",
-        "]"
-      })
-    )
+  it("doesn't collapse array with nested child comments", function()
+    local text = {
+      "[",
+      "  1,",
+      "  2,",
+      "  [ # a",
+      "    3, # b",
+      "    4, # c",
+      "=begin",
+      "a multiline comment here",
+      "and one more line",
+      "=end",
+      "    5 # d",
+      "  ]",
+      "]"
+    }
+    assert.are.same(text, Helper:call(text))
   end)
 
 end)

--- a/spec/filetypes/ruby_spec.lua
+++ b/spec/filetypes/ruby_spec.lua
@@ -253,4 +253,14 @@ describe("array", function()
     assert.are.same(text, Helper:call(text))
   end)
 
+  it("doesn't collapse array with inline comments", function()
+    local text = {
+      "[",
+      "  1, # no comment",
+      "  2,",
+      "]"
+    }
+    assert.are.same(text, Helper:call(text))
+  end)
+
 end)

--- a/spec/filetypes/ruby_spec.lua
+++ b/spec/filetypes/ruby_spec.lua
@@ -218,4 +218,43 @@ describe("array", function()
       })
     )
   end)
+
+  it("collapses multi-line array and skips embedded comments", function()
+    assert.are.same(
+      { "[1, 2, 3]" },
+      Helper:call({
+        "[ # a",
+        "  1, # b",
+        "  2, # c",
+        "=begin",
+        "a multiline comment here",
+        "and one more line",
+        "=end",
+        "  3 # d",
+        "]"
+      })
+    )
+  end)
+
+  it("collapses child arrays and skips embedded comments", function()
+    assert.are.same(
+      { "[1, 2, [3, 4, 5]]" },
+      Helper:call({
+        "[",
+        "  1,",
+        "  2,",
+        "  [ # a",
+        "    3, # b",
+        "    4, # c",
+        "=begin",
+        "a multiline comment here",
+        "and one more line",
+        "=end",
+        "    5 # d",
+        "  ]",
+        "]"
+      })
+    )
+  end)
+
 end)


### PR DESCRIPTION
Hi!

This plugin has been super helpful for me (thank you!), so I built out more python support.   I tried to keep commits isolated to `filetypes/python.lua` to avoid design decisions, but there are a few non-breaking changes outside of it.  I try to give context/explain the reason why for each (see below: Core Changes).

Features:
--
Comprehensions:
```python
# list_comprehension
xs = [x for x in range(10) if x - 3 or -x and x - 3 == 0 and abs(x - 1) < 2]
# set_comprehension
xs = {x for x in range(10)}
# dictionary_comprehension
xs = {x: 1 for x in range(10)}
# generator_expression
xs = (x for x in range(10))
# more complex example
xs = xs + bar([x for x in range(10) if x - 3 or -x and x - 3 == 0]) + xs
```
The result of toggle_multiline() on the complex example (cursor on the square bracket):
```python
xs = xs + bar([
                  x
                  for x in range(10)
                  if x - 3 or -x and x - 3 == 0
              ]) + xs
```

Inlined if statements:
```python
# assignment
x = 1 if foo() > 100 else 2
# multi assignment
x = y = z = 1 if foo() > 100 else 2
# return
return 1 if foo() > 100 else 2
# fn call
print(3) if True else print(4)
# lambda
x = (lambda y: y + 1) if foo() > 100 else (lambda y: y - 1)
# 1 line if_statement
if x: foo()
# 1 line if statement with ternary if
if x: foo() if y else bar()
# 1 line for statement with ternary if
for x in range(10): y = x + 1 if x < 2 else x - 1
```
are expanded (via _node_action on the `if`_) to:
```python
# assignment
if foo() > 100:
    x = 1
else:
    x = 2
# multi assignment
if foo() > 100:
    x = y = z = 1
else:
    x = y = z = 2
# return
if foo() > 100:
    return 1
else:
    return 2
# fn call
if True:
    print(3)
else:
    print(4)
# lambda
if foo() > 100:
    x = (lambda y: y + 1)
else:
    x = (lambda y: y - 1)
# 1 line if_statement
if x:
    foo()
# 1 line if statement with ternary if (cursor on first `if`)
if x:
    foo() if y else bar()
# 1 line if statement with ternary if (cursor on ternary `if`)
if x:
    if y:
        foo()
    else:
        bar()
# 1 line for statement with ternary if
for x in range(10):
    if x < 2:
        y = x + 1
    else:
        y = x - 1
```
These expanded forms can all be inlined, but when it can't safely do so or when it doesn't make sense to, it won't.

Core Changes
--
1. `init.lua:do_action()` - An optional `target_node` can be returned by actions and used as the target for replacement. 

This was used for python's "if/else <-> ternary", where the parent of the node being acted on is instead the one that needs to be replaced.  For example:
```python
x = 1 if y is not None and foo() > 100 else 2
```
The `if` is a "conditional_expression" that initiates the node_action.  Once expanded, the `if` is again the target for the inline_if_stmt node_action.
```python
if y is not None and foo() > 100:
    x = 1
else:
    x = 2
```
2. `init.lua:replace_node()` - The options returned by an action gained a `trim_whitespace` key that trims trailing whitespace between the `start_row` and `end_row`.  It is a table expecting keys by the same name, with relative values adjust the default ones, to match the cursor row/col design and behavior.

This was necessary to support expanding: 
```python
for x in range(10): y = 1 if x < 2 else x - 1
```
The expanded replacement needs to go on the next line and leaves behind 1 trailing whitespace.  For example, expanding this becomes:
```python
for x in range(10):_
    if x < 2:
        y = 1
    else:
        y = x - 1
```
The `_` marks the whitespace error, which is a gap left between the `for_statement` and previously inlined `body`.  The only way around this that I saw, was to leverage (1.) to replace the entire for/if statement node, but maybe the whitespace trimming will be useful to others.

3. `helpers.padded_node_text()` can now accept `padding` with values that are optionally a table instead of a string.  I did my best to document it with comments, so I won't repeat it here, since this is already a wall a text.  It receives a `prev_text` param from `toggle_multiline.lua:collapse_child_nodes()` that allows it to be semi-context aware.

The tldr reason why, is that the expected `_is_not_` and `_not_in_` would be padded as `_is__not_` and `_not__in_` and it needed to be smart enough to only have 1 space between them.  But also for unary/binary `-`, it can now pad differently for each.