### PR TITLE
Minor fix of expected behavior of multiline_node and slightly rename

### DIFF
--- a/README.md
+++ b/README.md
@@ -184,7 +184,7 @@ This will present the available node action(s) for the node under your cursor al
 Returns the text of the specified node.
 <hr>
 
-`require("ts-node-action.helpers").multiline_node(node)`
+`require("ts-node-action.helpers").node_is_multiline(node)`
 ```
 @node: tsnode
 @return: boolean

--- a/doc/ts-node-action.txt
+++ b/doc/ts-node-action.txt
@@ -266,7 +266,7 @@ Returns the text of the specified node.
 
 <hr>
 
-`require("ts-node-action.helpers").multiline_node(node)`
+`require("ts-node-action.helpers").node_is_multiline(node)`
 
 >
     @node: tsnode

--- a/lua/ts-node-action/actions/toggle_multiline.lua
+++ b/lua/ts-node-action/actions/toggle_multiline.lua
@@ -41,10 +41,10 @@ return function(padding)
 
   local function action(node)
     local fn
-    if helpers.multiline_node(node) then
-      fn = expand_child_nodes
-    else
+    if helpers.node_is_multiline(node) then
       fn = collapse_child_nodes(padding)
+    else
+      fn = expand_child_nodes
     end
     return fn(node), { cursor = {}, format = true }
   end

--- a/lua/ts-node-action/filetypes/ruby.lua
+++ b/lua/ts-node-action/filetypes/ruby.lua
@@ -20,13 +20,7 @@ local function toggle_block(node)
   local structure = helpers.destructure_node(node)
   local replacement
 
-  if helpers.multiline_node(node) then
-    if structure.parameters then
-      replacement = { "do " .. structure.parameters, structure.body, "end" }
-    else
-      replacement = { "do", structure.body, "end" }
-    end
-  else
+  if helpers.node_is_multiline(node) then
     if string.find(structure.body, "\n") then
       print("(TS:Action) Cannot collapse multi-line block")
       return
@@ -36,6 +30,12 @@ local function toggle_block(node)
       replacement = "{ " .. structure.parameters .. " " .. structure.body .. " }"
     else
       replacement = "{ " .. structure.body .. " }"
+    end
+  else
+    if structure.parameters then
+      replacement = { "do " .. structure.parameters, structure.body, "end" }
+    else
+      replacement = { "do", structure.body, "end" }
     end
   end
 

--- a/lua/ts-node-action/helpers.lua
+++ b/lua/ts-node-action/helpers.lua
@@ -12,9 +12,9 @@ end
 --
 -- @param node tsnode
 -- @return boolean
-function M.multiline_node(node)
+function M.node_is_multiline(node)
   local start_row, _, end_row, _ = node:range()
-  return start_row == end_row
+  return start_row ~= end_row
 end
 
 -- Adds whitespace to some unnamed nodes for nicer formatting

--- a/lua/ts-node-action/helpers.lua
+++ b/lua/ts-node-action/helpers.lua
@@ -12,10 +12,21 @@ end
 --
 -- @param node tsnode
 -- @return boolean
+-- @deprecated
+function M.multiline_node(node)
+  print("(TS-NODE-ACTION) helpers.multiline_node() is deprecated! Update your calls to helpers.node_is_multiline()")
+  return not M.node_is_multiline(node)
+end
+
+-- Determine if a node spans multiple lines
+--
+-- @param node tsnode
+-- @return boolean
 function M.node_is_multiline(node)
   local start_row, _, end_row, _ = node:range()
   return start_row ~= end_row
 end
+
 
 -- Adds whitespace to some unnamed nodes for nicer formatting
 -- `padding` is a table where the key is the text of the unnamed node, and the value


### PR DESCRIPTION
`helpers.multiline_node()` currently returns `false` if it is multiline (true for single line), which is incorrect according to the docs and is unexpected.

This changes it to return true when a node is multiline and otherwise false.   It also slightly renames it, with a literate style that aligns with `helpers.node_text()`, ie, "{subject}_{action}".

Sigh, because it's documented so it's a breaking change, even without renaming (my other PR will need to updated if this is accepted).  The plugin might not be old enough to worry about deprecation.

I thought about filing an issue, but might as well toss up a quick PR.