### PR TITLE
fix: toggle_operator breaks in multiline context

### DIFF
--- a/lua/ts-node-action/actions/toggle_operator.lua
+++ b/lua/ts-node-action/actions/toggle_operator.lua
@@ -14,16 +14,14 @@ return function(operator_override)
     default_operators, operator_override or {})
 
   local function action(node)
-    local replacement = {}
     for child, _ in node:iter_children() do
-      local text = helpers.node_text(child)
-      if operators[text] then
-        table.insert(replacement, operators[text])
-      else
-        table.insert(replacement, text)
+      if child:named() == false then
+        local text = helpers.node_text(child)
+        if operators[text] then
+          return {operators[text]}, {target = child}
+        end
       end
     end
-    return table.concat(replacement, " ")
   end
 
   return { { action, name = "Toggle Operator" } }

--- a/spec/filetypes/python/comparison_operator_spec.lua
+++ b/spec/filetypes/python/comparison_operator_spec.lua
@@ -1,0 +1,24 @@
+dofile("./spec/spec_helper.lua")
+
+local Helper = SpecHelper.new("python", { shiftwidth = 4 })
+
+describe("comparison_operator", function()
+
+  it("toggles operator in multiline context", function()
+    assert.are.same(
+      {
+        [[if (100 <]],
+        [[    foo(x,]],
+        [[        y)):]],
+        [[    x = 1]],
+      },
+      Helper:call({
+        [[if (100 >]],
+        [[    foo(x,]],
+        [[        y)):]],
+        [[    x = 1]],
+      }, {1, 9})
+    )
+  end)
+
+end)


### PR DESCRIPTION
### Issue:
```python
if (100 >
    foo(x,
        y)):
    x = 1
```
On master, toggling `>` produces this error:
```
E5108: Error executing lua ...ts-node-action/init.lua:49: invalid value (table) at index 3 in table for 'concat'
```
Before the change to `helpers.node_text()` it produced this error:
```
E5108: Error executing lua .../ts-node-action/init.lua:15: String cannot contain newlines
```

### Implementation:

This alters `actions.toggle_operator()` to only replace the unnamed node for `>`, by targeting it directly, rather than replacing the entire expression.

#### Bonus:
This will now preserve the original formatting.  Previously, it collapsed the expression, eg:
```python
if (100 >
    foo(x, y)):
    x = 1
```
became:
```python
if (100 > foo(x, y)):
    x = 1
```