### PR TITLE
fix: toggle_operator() support for languages that target a childless node

### DIFF
--- a/.github/workflows/spec.yml
+++ b/.github/workflows/spec.yml
@@ -46,7 +46,7 @@ jobs:
 
       - name: Compile parsers
         run: |
-          nvim --headless -c "TSInstallSync ruby python lua javascript yaml" -c "q"
+          nvim --headless -c "TSInstallSync ruby python lua javascript julia yaml" -c "q"
       - name: Tests
         env:
           ci: "1"

--- a/lua/ts-node-action/actions/toggle_operator.lua
+++ b/lua/ts-node-action/actions/toggle_operator.lua
@@ -14,11 +14,19 @@ return function(operator_override)
     default_operators, operator_override or {})
 
   local function action(node)
-    for child, _ in node:iter_children() do
-      if child:named() == false then
-        local text = helpers.node_text(child)
-        if operators[text] then
-          return {operators[text]}, {target = child}
+    if node:child_count() == 0 then
+      local text = helpers.node_text(node)
+      if operators[text] then
+        return operators[text]
+      end
+      return
+    else
+      for child, _ in node:iter_children() do
+        if child:named() == false then
+          local text = helpers.node_text(child)
+          if operators[text] then
+            return operators[text], { target = child }
+          end
         end
       end
     end

--- a/lua/ts-node-action/actions/toggle_operator.lua
+++ b/lua/ts-node-action/actions/toggle_operator.lua
@@ -19,7 +19,6 @@ return function(operator_override)
       if operators[text] then
         return operators[text]
       end
-      return
     else
       for child, _ in node:iter_children() do
         if child:named() == false then

--- a/lua/ts-node-action/filetypes/init.lua
+++ b/lua/ts-node-action/filetypes/init.lua
@@ -2,6 +2,7 @@ return {
   ["*"]           = require("ts-node-action.filetypes.global"),
   lua             = require("ts-node-action.filetypes.lua"),
   json            = require("ts-node-action.filetypes.json"),
+  julia           = require("ts-node-action.filetypes.julia"),
   yaml            = require("ts-node-action.filetypes.yaml"),
   ruby            = require("ts-node-action.filetypes.ruby"),
   eruby           = require("ts-node-action.filetypes.ruby"),

--- a/lua/ts-node-action/filetypes/julia.lua
+++ b/lua/ts-node-action/filetypes/julia.lua
@@ -1,0 +1,5 @@
+local actions = require("ts-node-action.actions")
+
+return {
+	["operator"] = actions.toggle_operator(),
+}

--- a/lua/ts-node-action/filetypes/julia.lua
+++ b/lua/ts-node-action/filetypes/julia.lua
@@ -1,5 +1,5 @@
 local actions = require("ts-node-action.actions")
 
 return {
-	["operator"] = actions.toggle_operator(),
+  ["operator"] = actions.toggle_operator(),
 }

--- a/spec/filetypes/julia_spec.lua
+++ b/spec/filetypes/julia_spec.lua
@@ -1,0 +1,11 @@
+dofile("spec/spec_helper.lua")
+
+local Helper = SpecHelper.new("julia", { shiftwidth = 2 })
+
+describe("operator", function()
+
+	it("toggles '>=' into '<='", function()
+		assert.are.same({ "i <= 8" }, Helper:call({ "i >= 8" }, { 1, 3 }))
+	end)
+
+end)

--- a/spec/filetypes/julia_spec.lua
+++ b/spec/filetypes/julia_spec.lua
@@ -3,9 +3,7 @@ dofile("spec/spec_helper.lua")
 local Helper = SpecHelper.new("julia", { shiftwidth = 2 })
 
 describe("operator", function()
-
-	it("toggles '>=' into '<='", function()
-		assert.are.same({ "i <= 8" }, Helper:call({ "i >= 8" }, { 1, 3 }))
-	end)
-
+  it("toggles '>=' into '<='", function()
+    assert.are.same({ "i <= 8" }, Helper:call({ "i >= 8" }, { 1, 3 }))
+  end)
 end)


### PR DESCRIPTION
Issue reported here:
https://github.com/CKolkey/ts-node-action/issues/29#issuecomment-1462864159

This fixes `toggle_operator()` in `Julia` and any language that act on the equivalent of an `operator` node that has no children.

Includes a short julia spec that tests this case.