### PR TITLE
Add R multiline support

### DIFF
--- a/README.md
+++ b/README.md
@@ -261,7 +261,7 @@ Builtin actions are all higher-order functions so they can easily have options o
 | `toggle_boolean()` | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ |  |  | ✅ | ✅ |
 | `cycle_case()` | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ |  |  |  | ✅ | ✅ |
 | `cycle_quotes()` | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ |  |  |  |  | ✅ |
-| `toggle_multiline()` |  | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ |  |  |  |
+| `toggle_multiline()` |  | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ |  |  | ✅ |
 | `toggle_operator()` |  | ✅ | ✅ | ✅ | ✅ | ✅ |  |  |  |  | ✅ |
 | `toggle_int_readability()` |  | ✅ | ✅ |  | ✅ | ✅ | ✅ | ✅ |  |  |  |
 | `toggle_block()` |  | ✅ |  |  |  |  |  |  |  |  |  |

--- a/lua/ts-node-action/filetypes/r.lua
+++ b/lua/ts-node-action/filetypes/r.lua
@@ -1,4 +1,5 @@
 local actions = require("ts-node-action.actions")
+local helpers = require("ts-node-action.helpers")
 
 local boolean_override = {
 	["TRUE"] = "FALSE",
@@ -22,8 +23,42 @@ local operators = {
 	["&&"] = "||",
 }
 
+local padding = {
+	[","] = "%s ",
+	["="] = " %s ",
+}
+
+--- @param node TSNode
+local function toggle_multiline_args(node)
+	local structure = helpers.destructure_node(node)
+	if (type(structure["arguments"]) == "table") or (type(structure["arguments"]) == "string") then
+	else
+		vim.print("No arguments")
+		return
+	end
+
+	local range_end = {}
+	range_end = { node:named_child(0):range() }
+	local replacement
+
+	if helpers.node_is_multiline(node) then
+		local tbl = actions.toggle_multiline(padding)
+		replacement = tbl[1][1](node)
+	else
+		replacement = { structure["function"] .. "(" }
+		for k in string.gmatch(structure.arguments, "([^,]+)") do
+			table.insert(replacement, k .. ",")
+		end
+		replacement[#replacement] = string.gsub(replacement[#replacement], "(.*)%,$", "%1")
+		table.insert(replacement, ")")
+	end
+
+	return replacement, { cursor = { col = range_end[4] - range_end[2] }, format = true }
+end
 return {
 	["true"] = actions.toggle_boolean(boolean_override),
 	["false"] = actions.toggle_boolean(boolean_override),
 	["binary"] = actions.toggle_operator(operators),
+	["call"] = { { toggle_multiline_args, name = "Toggle Multiline Arguments" } },
+	["formal_parameters"] = actions.toggle_multiline(padding),
 }

--- a/spec/filetypes/r_spec.lua
+++ b/spec/filetypes/r_spec.lua
@@ -11,3 +11,51 @@ describe("boolean", function()
 		assert.are.same({ "i == TRUE" }, Helper:call({ "i == FALSE" }, { 1, 7 }))
 	end)
 end)
+
+describe("multiline", function()
+	it("expand single line formal parameters to multiline", function()
+		assert.are.same({
+			"foo <- function(",
+			"  bar,",
+			"  baz",
+			")",
+		}, Helper:call({ "foo <- function(bar, baz)" }, { 1, 16 }))
+	end)
+
+	it("collapse multiline formal parameters to single line", function()
+		assert.are.same(
+			{ "foo <- function(bar, baz)" },
+			Helper:call({
+				"foo <- function(",
+				"  bar,",
+				"  baz",
+				")",
+			}, { 1, 16 })
+		)
+	end)
+end)
+
+describe("multiline_args", function()
+	it("expand single line arguments to multiline", function()
+		assert.are.same({
+			"foo(",
+			"  bar = buf,",
+			"  'baz',",
+			"  'bap'",
+			")",
+		}, Helper:call({ "foo(bar = buf, 'baz', 'bap')" }, { 1, 4 }))
+	end)
+
+	it("collapse multiline arguments to single line", function()
+		assert.are.same(
+			{ "foo(bar = buf, 'baz', 'bap')" },
+			Helper:call({
+				"foo(",
+				"  bar = buf,",
+				"  'baz',",
+				"  'bap'",
+				"  )",
+			}, { 1, 4 })
+		)
+	end)
+end)


### PR DESCRIPTION
This adds preliminary support for multiline toggle in R for function definition formal parameters and argument lists. Marking as draft as I can not figure out how to get the first argument to start on a newline, as the "arguments" node does not include the surrounding parenthesis, unlike the "formal_parameters" node.

Ideally this is how it would function

```r
foo('bar', 'baz')

foo(
  'bar',
  'baz'
)
```