### PR TITLE
feat: add support for cycling quotes in python

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,6 +102,18 @@ To define multiple actions for a node type, structure your `node_type` value as 
 
 `vim.ui.select` will use the value of `name` to when prompting you on which action to perform.
 
+If you want to bypass `vim.ui.select` and instead just want all actions to be applied
+without prompting, you can pass `ask = false` as an argument in the `node_type` value.
+Using the same example as above, it would look like this:
+
+```lua
+["node_type"] = {
+  { function_one, name = "Action One" },
+  { function_two, name = "Action Two" },
+  ask = false,
+}
+```
+
 ## Writing your own Node Actions
 
 All node actions should be a function that takes one argument: the tree-sitter node under the cursor.

--- a/lua/ts-node-action/init.lua
+++ b/lua/ts-node-action/init.lua
@@ -116,8 +116,10 @@ M.node_action = require("ts-node-action.repeat").set(function()
   if type(action) == "function" then
     do_action(action, node)
   elseif type(action) == "table" then
-    if #action == 1 then
-      do_action(action[1][1], node)
+    if action.ask == false or #action == 1 then
+      for _, act in ipairs(action) do
+        do_action(act[1], node)
+      end
     else
       vim.ui.select(action, {
         prompt = "Select Action",

--- a/spec/filetypes/python/quotes_spec.lua
+++ b/spec/filetypes/python/quotes_spec.lua
@@ -1,0 +1,83 @@
+dofile("./spec/spec_helper.lua")
+
+local Helper = SpecHelper.new("python", { shiftwidth = 4 })
+
+local single = "'"
+local double = '"'
+local triple1 = "'''"
+local triple2 = '"""'
+
+describe("string", function()
+  it("toggles " .. single .. " into " .. double, function()
+    local input = { single .. "string" .. single }
+    local want = { double .. "string" .. double }
+    assert.are.same(want, Helper:call(input, { 1, 1 }))
+    assert.are.same(want, Helper:call(input, { 1, 4 }))
+    assert.are.same(want, Helper:call(input, { 1, #input }))
+  end)
+  it("toggles " .. double .. " into " .. single, function()
+    local input = { double .. "string" .. double }
+    local want = { single .. "string" .. single }
+    assert.are.same(want, Helper:call(input, { 1, 1 }))
+    assert.are.same(want, Helper:call(input, { 1, 4 }))
+    assert.are.same(want, Helper:call(input, { 1, #input }))
+  end)
+  it("toggles " .. triple1 .. " into " .. triple2, function()
+    local input = { triple1 .. "string" .. triple1 }
+    local want = { triple2 .. "string" .. triple2 }
+    assert.are.same(want, Helper:call(input, { 1, 1 }))
+    assert.are.same(want, Helper:call(input, { 1, 4 }))
+    assert.are.same(want, Helper:call(input, { 1, #input }))
+  end)
+  it("toggles " .. triple2 .. " into " .. triple1, function()
+    local input = { triple2 .. "string" .. triple2 }
+    local want = { triple1 .. "string" .. triple1 }
+    assert.are.same(want, Helper:call(input, { 1, 1 }))
+    assert.are.same(want, Helper:call(input, { 1, 4 }))
+    assert.are.same(want, Helper:call(input, { 1, #input }))
+  end)
+  it(
+    "toggles multi-line " .. triple2 .. " into multi-line " .. triple1,
+    function()
+      local input = { triple2, "string", triple2 }
+      local want = { triple1, "string", triple1 }
+      assert.are.same(want, Helper:call(input, { 1, 1 }))
+      assert.are.same(want, Helper:call(input, { 2, 1 }))
+      assert.are.same(want, Helper:call(input, { 3, 1 }))
+    end
+  )
+  it(
+    "toggles multi-line " .. triple1 .. " into multi-line " .. triple2,
+    function()
+      local input = { triple1, "string", triple1 }
+      local want = { triple2, "string", triple2 }
+      assert.are.same(want, Helper:call(input, { 1, 1 }))
+      assert.are.same(want, Helper:call(input, { 2, 1 }))
+      assert.are.same(want, Helper:call(input, { 3, 1 }))
+    end
+  )
+  it("toggles f-strings", function()
+    local input = { "f" .. single .. "string {foo}" .. single }
+    local want = { "f" .. double .. "string {foo}" .. double }
+    assert.are.same(want, Helper:call(input, { 1, 1 }))
+    assert.are.same(want, Helper:call(input, { 1, 4 }))
+    assert.are.same(want, Helper:call(input, { 1, #input }))
+  end)
+  it("toggles multi-line f-strings", function()
+    local input = { "f" .. triple2, "string {foo}", triple2 }
+    local want = { "f" .. triple1, "string {foo}", triple1 }
+    assert.are.same(want, Helper:call(input, { 1, 1 }))
+    assert.are.same(want, Helper:call(input, { 2, 1 }))
+    assert.are.same(want, Helper:call(input, { 3, 1 }))
+  end)
+  it("toggles multi-line f-string with nested string", function()
+    local input = { "f" .. triple2, 'string {"nested"}', triple2 }
+    local want_outer = { "f" .. triple1, 'string {"nested"}', triple1 }
+    assert.are.same(want_outer, Helper:call(input, { 1, 1 }))
+    assert.are.same(want_outer, Helper:call(input, { 2, 1 }))
+    assert.are.same(want_outer, Helper:call(input, { 3, 1 }))
+
+    local want_nested = { "f" .. triple2, "string {'nested'}", triple2 }
+    assert.are.same(want_nested, Helper:call(input, { 2, 12 }))
+  end)
+end)


### PR DESCRIPTION
Python has separate node types for the start, content and end of a string. The string start and end always contain the quote characters (including any modifiers, like `f` or `r` for format and raw strings respectively). When the cursor is on any of the these nodes, it should start toggling quotes.

This PR adds an action that triggers on any string node (start/content/end) and toggles both `string_start` and `string_end` within the same action. I found no way to trigger two replacements from the same action, so I added an optional boolean parameter `ask` to the action table which is `true` by default for backwards compatibility. When `find_action` receives multiple actions for a given node, it now checks this parameter to decide if `vim.ui.select` should be called to let the user choose an action or if it will just run all actions without asking.

This allows to define a function that returns a table like this

```lua
  {
    { toggle_start, name = "Toggle string start quote" },
    { toggle_end,   name = "Toggle string end quote" },
    ask = false
  }
```

which will run `toggle_start` and `toggle_end` without asking and replace the respective nodes.

It would also be possible to do it in one action by finding the parent node `string` first and replacing the whole string. However, this is much more error-prone and more complex to implement when dealing with Python multi-line strings, f-strings or nested strings and so on.
