### PR TITLE
change: make toggle for boolean node available for all languages

### DIFF
--- a/lua/ts-node-action/actions/toggle_boolean.lua
+++ b/lua/ts-node-action/actions/toggle_boolean.lua
@@ -3,6 +3,10 @@ local helpers = require("ts-node-action.helpers")
 local boolean_pair_default = {
   ["true"]  = "false",
   ["false"] = "true",
+  ["True"]  = "False",
+  ["False"] = "True",
+  ["TRUE"] = "FALSE",
+  ["FALSE"] = "TRUE",
 }
 
 return function(boolean_pair_override)

--- a/lua/ts-node-action/filetypes/global.lua
+++ b/lua/ts-node-action/filetypes/global.lua
@@ -3,6 +3,7 @@ local actions = require("ts-node-action.actions")
 return {
   ["true"]          = actions.toggle_boolean(),
   ["false"]         = actions.toggle_boolean(),
+  ["boolean"]       = actions.toggle_boolean(),
   ["identifier"]    = actions.cycle_case(),
   ["variable_name"] = actions.cycle_case(),
   ["string"]        = actions.cycle_quotes(),

--- a/lua/ts-node-action/filetypes/lua.lua
+++ b/lua/ts-node-action/filetypes/lua.lua
@@ -62,8 +62,6 @@ local function toggle_named_function(node)
 end
 
 return {
-  ["false"]                = actions.toggle_boolean(),
-  ["true"]                 = actions.toggle_boolean(),
   ["table_constructor"]    = actions.toggle_multiline(padding),
   ["arguments"]            = actions.toggle_multiline(padding),
   ["binary_expression"]    = actions.toggle_operator(operator_override),

--- a/lua/ts-node-action/filetypes/php.lua
+++ b/lua/ts-node-action/filetypes/php.lua
@@ -36,7 +36,6 @@ return {
   ["compound_statement"]        = actions.toggle_multiline(padding),
   ["name"]                      = actions.cycle_case(),
   ["encapsed_string"]           = actions.cycle_quotes(),
-  ["boolean"]                   = actions.toggle_boolean(),
   ["binary_expression"]         = actions.toggle_operator(operators),
   ["integer"]                   = actions.toggle_int_readability(),
 }

--- a/lua/ts-node-action/filetypes/python.lua
+++ b/lua/ts-node-action/filetypes/python.lua
@@ -50,11 +50,6 @@ local padding = {
   ["from"]   = "%s ",
 }
 
-local boolean_override = {
-  ["True"]  = "False",
-  ["False"] = "True",
-}
-
 --- @param node TSNode
 local function node_trim_whitespace(node)
   local start_row, _, end_row, _ = node:range()
@@ -524,8 +519,6 @@ return {
   ["set_comprehension"]        = actions.toggle_multiline(padding),
   ["dictionary_comprehension"] = actions.toggle_multiline(padding),
   ["generator_expression"]     = actions.toggle_multiline(padding),
-  ["true"]                     = actions.toggle_boolean(boolean_override),
-  ["false"]                    = actions.toggle_boolean(boolean_override),
   ["comparison_operator"]      = actions.toggle_operator(),
   ["integer"]                  = actions.toggle_int_readability(),
   ["conditional_expression"]   = { expand_conditional_expression(padding), },

--- a/lua/ts-node-action/filetypes/r.lua
+++ b/lua/ts-node-action/filetypes/r.lua
@@ -1,11 +1,6 @@
 local actions = require("ts-node-action.actions")
 local helpers = require("ts-node-action.helpers")
 
-local boolean_override = {
-	["TRUE"] = "FALSE",
-	["FALSE"] = "TRUE",
-}
-
 local operators = {
 	["!="] = "==",
 	["=="] = "!=",
@@ -56,8 +51,6 @@ local function toggle_multiline_args(node)
 	return replacement, { cursor = { col = range_end[4] - range_end[2] }, format = true }
 end
 return {
-	["true"] = actions.toggle_boolean(boolean_override),
-	["false"] = actions.toggle_boolean(boolean_override),
 	["binary"] = actions.toggle_operator(operators),
 	["call"] = { { toggle_multiline_args, name = "Toggle Multiline Arguments" } },
 	["formal_parameters"] = actions.toggle_multiline(padding),

--- a/lua/ts-node-action/filetypes/sql.lua
+++ b/lua/ts-node-action/filetypes/sql.lua
@@ -1,12 +1,5 @@
 local actions = require("ts-node-action.actions")
 
-local boolean_override = {
-    ["true"] = "false",
-    ["TRUE"] = "FALSE",
-    ["false"] = "true",
-    ["FALSE"] = "TRUE",
-}
-
 local operators = {
     ["!="] = "=",
     ["="] = "!=",
@@ -34,8 +27,8 @@ local uncollapsible = {
 }
 
 return {
-    ["keyword_true"]       = actions.toggle_boolean(boolean_override),
-    ["keyword_false"]      = actions.toggle_boolean(boolean_override),
+    ["keyword_true"]       = actions.toggle_boolean(),
+    ["keyword_false"]      = actions.toggle_boolean(),
     ["binary_expression"]  = actions.toggle_operator(operators),
     ["keyword_and"]        = actions.toggle_operator(operators),
     ["keyword_or"]         = actions.toggle_operator(operators),


### PR DESCRIPTION
I think it is safe to make the `toggle_boolean` action for nodes of type `boolean` available globally. Additionally, the different casings of true/false like `true`, `True` or `TRUE` should be included in the default accepted boolean values. If a language does not allow a specific case (like Python only allows `True`, no other variant), then usually linters or language servers will already complain.

It is more convenient to have such common node type like `boolean` available for all languages instead of having to configure an action for each new language that is encountered. For example, I recently added a TOML configuration file, and noticed that toggling of booleans was not yet working and had to add it to the config file first. I see no reason why it shouldn't be the default in all languages to trigger `toggle_boolean` here.