### PR TITLE
fix(#53): remove deprecated `vim.pretty_print()` function

### DIFF
--- a/lua/ts-node-action/helpers.lua
+++ b/lua/ts-node-action/helpers.lua
@@ -105,7 +105,7 @@ function M.debug_print_tree(node)
     index = index + 1
   end
 
-  vim.pretty_print(tree)
+  vim.print(tree)
 end
 
 -- Disassembles a node tree into it's named and unnamed parts


### PR DESCRIPTION
This PR Removes the deprecated `vim.pretty_print()` with the corresponding `vim.print()` as suggested by neovim