### PR TITLE
Explicitly specify the range of the substitution as an option

### DIFF
--- a/README.md
+++ b/README.md
@@ -182,8 +182,9 @@ Boolean value. If `true`, will run `=` operator on new buffer text. Requires
 
 #### `target`
 
-TSNode. If present, this node will be used as the target for replacement instead
-of the node under your cursor.
+TSNode or table. To change the target of the substitution you can specify either a TSNode or a table.
+- If a TSNode, it will be used as the target of the substitution instead of the node under your cursor.
+- If a table, it must be specified as `{start_row, start_col, end_row, end_col}` and the specified range in the current buffer must be non-empty.
 
 Here's a simplified example of how a node-action function gets called:
 

--- a/doc/ts-node-action.txt
+++ b/doc/ts-node-action.txt
@@ -193,8 +193,9 @@ Boolean value. If `true`, will run `=` operator on new buffer text. Requires
 
 TARGET
 
-TSNode. If present, this node will be used as the target for replacement
-instead of the node under your cursor.
+TSNode or table. To change the target of the substitution you can specify either a TSNode or a table.
+- If a TSNode, it will be used as the target of the substitution instead of the node under your cursor.
+- If a table, it must be specified as `{start_row, start_col, end_row, end_col}` and the specified range in the current buffer must be non-empty.
 
 Here’s a simplified example of how a node-action function gets called:
 

--- a/lua/ts-node-action/init.lua
+++ b/lua/ts-node-action/init.lua
@@ -2,14 +2,22 @@ local M = {}
 
 --- @private
 --- @param replacement string|table
---- @param opts { cursor: { col: number, row: number }, callback: function, format: boolean, target: TSNode }
+--- @param opts {cursor: { col: number, row: number }, callback: function, format: boolean, target: TSNode|table}
 --- All opts fields are optional
 local function replace_node(node, replacement, opts)
   if type(replacement) ~= "table" then
     replacement = { replacement }
   end
 
-  local start_row, start_col, end_row, end_col = (opts.target or node):range()
+  local start_row, start_col, end_row, end_col
+  if not opts.target then
+    start_row, start_col, end_row, end_col = node:range()
+  elseif type(opts.target) == "TSNode" then
+    start_row, start_col, end_row, end_col = opts.target:range()
+  else
+    start_row, start_col, end_row, end_col = table.unpack(opts.target)
+  end
+
   vim.api.nvim_buf_set_text(
     vim.api.nvim_get_current_buf(),
     start_row,


### PR DESCRIPTION
## Hi
Just wanted to say i really like and appreciate the work.

## Content
The user is given the possibility to explicitly specify the range of the substitution by passing a table as an alternative to the target node. This way one may have, if needed, more control on the specific section of the buffer that will be overridden.

## Motivation
It's necessary to have this kind of precision, for example, in cases in which one wants to insert some text without performing substitutions.\
One use case would be the generation of automatic documentation - which is the problem i personally faced.

## Possible fallbaks

If the user specifies an unexistent range in the buffer, neovim will report an error.

## Checklist

- [X] doc updated
- [X] it works on my machine
