### PR TITLE
feat: support `php_only` parser

### DIFF
--- a/lua/ts-node-action/filetypes/init.lua
+++ b/lua/ts-node-action/filetypes/init.lua
@@ -8,6 +8,7 @@ return {
   eruby = require("ts-node-action.filetypes.ruby"),
   python = require("ts-node-action.filetypes.python"),
   php = require("ts-node-action.filetypes.php"),
+  php_only = require("ts-node-action.filetypes.php"),
   rust = require("ts-node-action.filetypes.rust"),
   html = require("ts-node-action.filetypes.html"),
   javascript = require("ts-node-action.filetypes.javascript"),


### PR DESCRIPTION
The php parser has been split into two distinct parsers for quite some
time; `php` and `php_only`.

See https://github.com/tree-sitter/tree-sitter-php/pull/192

This change allow to use node actions when only `php_only` parser is
installed.
