### PR TITLE
feat: remove hard dependency on `nvim-treesitter`

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,7 +39,6 @@ with the result.
 ```lua
 {
     'ckolkey/ts-node-action',
-     dependencies = { 'nvim-treesitter' },
      opts = {},
 },
 ```
@@ -49,7 +48,6 @@ with the result.
 ```lua
 use({
     'ckolkey/ts-node-action',
-     requires = { 'nvim-treesitter' },
      config = function()
          require("ts-node-action").setup({})
      end

--- a/doc/ts-node-action.txt
+++ b/doc/ts-node-action.txt
@@ -43,7 +43,6 @@ INSTALLATION                      *ts-node-action-ts-node-action-installation*
 >lua
     {
         'ckolkey/ts-node-action',
-         dependencies = { 'nvim-treesitter' },
          opts = {},
     },
 <
@@ -53,7 +52,6 @@ INSTALLATION                      *ts-node-action-ts-node-action-installation*
 >lua
     use({
         'ckolkey/ts-node-action',
-         requires = { 'nvim-treesitter' },
          config = function()
              require("ts-node-action").setup({})
          end

--- a/lua/ts-node-action/init.lua
+++ b/lua/ts-node-action/init.lua
@@ -1,5 +1,7 @@
 local M = {}
 
+local ts = vim.treesitter
+
 --- @private
 --- @param targets TSNode[]
 --- @return integer start_row
@@ -124,14 +126,18 @@ end
 --- @return TSNode, string
 --- @return nil
 function M._get_node()
-  local root_langtree = require("nvim-treesitter.parsers").get_parser()
-  if not root_langtree then
+  -- stylua: ignore
+  local parser = (vim.fn.has("nvim-0.12") == 1 and ts.get_parser())
+    or (vim.fn.has("nvim-0.11") == 1 and ts.get_parser(nil, nil, { error = false }))
+    or (pcall(ts.get_parser, nil, nil))
+
+  if not parser then
     return
   end
 
   local lnum, col = unpack(vim.api.nvim_win_get_cursor(0))
   local range4 = { lnum - 1, col, lnum - 1, col }
-  local langtree = root_langtree:language_for_range(range4)
+  local langtree = parser:language_for_range(range4)
   local node = langtree:named_node_for_range(range4)
   return node, langtree:lang()
 end


### PR DESCRIPTION
Remove hard dependency on `nvim-treesitter` for two reasons:

1. `vim.treesitter.get_parser` has been in Neovim core for 4 years.
2. nvim-treesitter's future focus will be on parser installation and
   query aggregation only.

Use Neovim's built-in TreeSitter API instead.

Closes #70
