### PR TITLE
fix: nvim 0.10.1 parser

### DIFF
--- a/lua/ts-node-action/init.lua
+++ b/lua/ts-node-action/init.lua
@@ -123,13 +123,12 @@ function M.setup(opts)
 end
 
 --- @private
---- @return TSNode, string
---- @return nil
+--- @return TSNode|nil, string|nil
 function M._get_node()
   -- stylua: ignore
   local parser = (vim.fn.has("nvim-0.12") == 1 and ts.get_parser())
-    or (vim.fn.has("nvim-0.11") == 1 and ts.get_parser(nil, nil, { error = false }))
-    or (pcall(ts.get_parser, nil, nil))
+      or (vim.fn.has("nvim-0.11") == 1 and ts.get_parser(nil, nil, { error = false }))
+      or (type(ts.get_parser) == "function" and ts.get_parser(nil, nil))
 
   if not parser then
     return


### PR DESCRIPTION
pcall() will return two values, the first being a boolean. Check if function exists instead as validation.

Fixes #72 